### PR TITLE
Add rimraf as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "microbundle": "^0.12.2",
     "mocha": "^7.2.0",
     "np": "^6.2.3",
+    "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "sourcemap": "^0.1.0",


### PR DESCRIPTION
Hey @adrienpoly,

Thanks for creating this project! I'm looking forward to contribute to `stimulus-use`. 

While following your instructions to setup the project locally, I noticed that `rimraf` was missing. I got the following error while running `yarn build`:

```
stimulus-use on master via v10.16.0
❯ yarn build
yarn run v1.22.4
$ yarn clean
$ rimraf dist *.tsbuildinfo
/bin/sh: rimraf: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I guess it's missing. After adding `rimraf` as a `devDependecy` to project built successfully. 
