### PR TITLE
adds the emitting controller to the custom event

### DIFF
--- a/docs/application-controller.md
+++ b/docs/application-controller.md
@@ -20,13 +20,14 @@ export default class extends Controller {
 **Extending a controller**
 
 ```js
+// greet_controller.js
 import { ApplicationController } from 'stimulus-use'
 
 export default class extends ApplicationController {
 
   connect() {
     this.isPreview // true/false if it is a Turbolinks preview
-    this.dispatch("hello") // helper to dispatch a custom event to other Stimulus controllers
+    this.dispatch("hello") // helper to dispatch a custom event "greet:hello" to other Stimulus controllers
   }
 }
 ```
@@ -88,6 +89,7 @@ export default class extends ApplicationController {
 
   refreshTotal(e) {
     this.counter += e.detail.quantity
+    console.log(e.detail.controller) // the emitting item_controller
   }
 
   renderCounter() {

--- a/playground/controllers/cart_controller.js
+++ b/playground/controllers/cart_controller.js
@@ -5,6 +5,7 @@ export default class extends ApplicationController {
 
   refreshTotal(e) {
     this.counter++
+    console.log(e.detail.controller)
   }
 
   renderCounter() {

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -6,6 +6,9 @@ export const useApplication = (controller: Controller) => {
       eventName: String,
       { target = controller.element, detail = {}, bubbles = true, cancelable = true } = {},
     ): CustomEvent {
+      // include the emitting controller in the event detail
+      Object.assign(detail, { controller })
+
       const type = `${controller.identifier}:${eventName}`
       const event = new CustomEvent(type, { detail, bubbles, cancelable })
       target.dispatchEvent(event)


### PR DESCRIPTION
When using `this.dispatch`  function from the application-controller it does automatically add the emitting controller to the `detail` of the event

```js
refreshTotal(e) {
    this.counter++
    console.log(e.detail.controller) // the item_controller
  }
```