### PR TITLE
fix observers are being overwritten

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -26,6 +26,8 @@
       <div data-controller="modal" data-action="modal:click:outside->modal#close" style="height: 3rem; width: 30rem; background-color: gray;">
         Click outside
         <button data-target="modal.content">Test</button>
+        <button data-action="modal#observe">Observe</button>
+        <button data-action="modal#unobserve">Unobserve</button>
       </div>
       <h1 class="mt-5">Example of using dispatch</h1>
       <p>Communication between 2 controllers item_controller and cart_controller</p>

--- a/src/use-click-outside/click-outside-controller.ts
+++ b/src/use-click-outside/click-outside-controller.ts
@@ -2,7 +2,6 @@ import { Controller, Context } from 'stimulus'
 import { useClickOutside, ClickOutsideOptions } from './use-click-outside'
 
 export class ClickOutsideController extends Controller {
-  observer!: ResizeObserver
   options!: ClickOutsideOptions
 
   constructor(context: Context) {

--- a/src/use-click-outside/click-outside-controller.ts
+++ b/src/use-click-outside/click-outside-controller.ts
@@ -3,11 +3,14 @@ import { useClickOutside, ClickOutsideOptions } from './use-click-outside'
 
 export class ClickOutsideController extends Controller {
   options!: ClickOutsideOptions
+  observe!: () => void
+  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
     requestAnimationFrame(() => {
-      useClickOutside(this, this.options)
+      const [observe, unobserve] = useClickOutside(this, this.options)
+      Object.assign(this, { observe, unobserve })
     })
   }
 

--- a/src/use-click-outside/use-click-outside.ts
+++ b/src/use-click-outside/use-click-outside.ts
@@ -42,9 +42,17 @@ export const useClickOutside = (controller: ClickOutsideController, options: Cli
     }
   }
 
-  events?.forEach(event => {
-    window.addEventListener(event, onEvent, false)
-  })
+  const observe = () => {
+    events?.forEach(event => {
+      window.addEventListener(event, onEvent, false)
+    })
+  }
+
+  const unobserve = () => {
+    events?.forEach(event => {
+      window.removeEventListener(event, onEvent, false)
+    })
+  }
 
   // keep a copy of the current disconnect() function of the controller
   // to support composing several behaviors
@@ -52,10 +60,12 @@ export const useClickOutside = (controller: ClickOutsideController, options: Cli
 
   Object.assign(controller, {
     disconnect() {
-      events?.forEach(event => {
-        window.removeEventListener(event, onEvent, false)
-      })
+      unobserve()
       controllerDisconnect()
     },
   })
+
+  observe()
+
+  return [observe, unobserve] as const
 }

--- a/src/use-idle/idle-controller.ts
+++ b/src/use-idle/idle-controller.ts
@@ -11,10 +11,6 @@ export class IdleController extends Controller {
     })
   }
 
-  observe() {}
-
-  unObserve() {}
-
   away() {}
 
   back() {}

--- a/src/use-idle/idle-controller.ts
+++ b/src/use-idle/idle-controller.ts
@@ -1,13 +1,18 @@
 import { Controller, Context } from 'stimulus'
-import { useIdle } from './use-idle'
+import { useIdle, IdleOptions } from './use-idle'
 
 export class IdleController extends Controller {
   isIdle: boolean = false
+  options!: IdleOptions
+  observe!: () => void
+  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
     requestAnimationFrame(() => {
       useIdle(this)
+      const [observe, unobserve] = useIdle(this, this.options)
+      Object.assign(this, { observe, unobserve })
     })
   }
 

--- a/src/use-idle/use-idle.ts
+++ b/src/use-idle/use-idle.ts
@@ -4,7 +4,7 @@ import { extendedEvent, method, composeEventName } from '../support'
 const defaultEvents = ['mousemove', 'mousedown', 'resize', 'keydown', 'touchstart', 'wheel']
 const oneMinute = 60e3
 
-interface IdleOptions {
+export interface IdleOptions {
   ms?: number
   initialState?: boolean
   events?: string[]

--- a/src/use-idle/use-idle.ts
+++ b/src/use-idle/use-idle.ts
@@ -76,25 +76,28 @@ export const useIdle = (controller: IdleController, options: IdleOptions = {}) =
   }
 
   const controllerDisconnect = controller.disconnect.bind(controller)
+  const observe = () => {
+    events.forEach(event => {
+      window.addEventListener(event, onEvent)
+    })
+    document.addEventListener('visibilitychange', onVisibility)
+  }
+
+  const unobserve = () => {
+    events.forEach(event => {
+      window.removeEventListener(event, onEvent)
+    })
+    document.removeEventListener('visibilitychange', onVisibility)
+  }
 
   Object.assign(controller, {
-    observe() {
-      events.forEach(event => {
-        window.addEventListener(event, onEvent)
-      })
-      document.addEventListener('visibilitychange', onVisibility)
-    },
-    unObserve() {
-      events.forEach(event => {
-        window.removeEventListener(event, onEvent)
-      })
-      document.removeEventListener('visibilitychange', onVisibility)
-    },
     disconnect() {
-      this.unObserve()
+      unobserve()
       controllerDisconnect()
     },
   })
 
-  controller.observe()
+  observe()
+
+  return [observe, unobserve] as const
 }

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -4,7 +4,6 @@ import { useIntersection, IntersectionOptions } from './use-intersection'
 export class IntersectionController extends Controller {
   isVisible: boolean = false
   options!: IntersectionOptions
-  observer!: IntersectionObserver
 
   constructor(context: Context) {
     super(context)
@@ -12,10 +11,6 @@ export class IntersectionController extends Controller {
       useIntersection(this, this.options)
     })
   }
-
-  observe() {}
-
-  unObserve() {}
 
   appear(entry: IntersectionObserverEntry) {}
 

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -4,11 +4,14 @@ import { useIntersection, IntersectionOptions } from './use-intersection'
 export class IntersectionController extends Controller {
   isVisible: boolean = false
   options!: IntersectionOptions
+  observe!: () => void
+  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
     requestAnimationFrame(() => {
-      useIntersection(this, this.options)
+      const [observe, unobserve] = useIntersection(this, this.options)
+      Object.assign(this, { observe, unobserve })
     })
   }
 

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -55,20 +55,25 @@ export const useIntersection = (controller: IntersectionController, options: Int
   // to support composing several behaviors
   const controllerDisconnect = controller.disconnect.bind(controller)
 
+  const observer = new IntersectionObserver(callback, options)
+
+  const observe = () => {
+    observer.observe(targetElement)
+  }
+
+  const unobserve = () => {
+    observer.unobserve(targetElement)
+  }
+
   Object.assign(controller, {
     isVisible: false,
-    observer: new IntersectionObserver(callback, options),
-    observe() {
-      this.observer.observe(targetElement)
-    },
-    unObserve() {
-      this.observer.unobserve(targetElement)
-    },
     disconnect() {
-      controller.unObserve()
+      unobserve()
       controllerDisconnect()
     },
   })
 
-  controller.observe()
+  observe()
+
+  return [observe, unobserve] as const
 }

--- a/src/use-lazy-load/lazy-load-controller.ts
+++ b/src/use-lazy-load/lazy-load-controller.ts
@@ -5,7 +5,6 @@ export class LazyLoadController extends Controller {
   isLoading: boolean = false
   isLoaded: boolean = false
   options: IntersectionObserverInit = { rootMargin: '10%' }
-  observer!: IntersectionObserver
 
   constructor(context: Context) {
     super(context)
@@ -13,10 +12,6 @@ export class LazyLoadController extends Controller {
       useLazyLoad(this, this.options)
     })
   }
-
-  observe() {}
-
-  unObserve() {}
 
   loading(src: string) {}
 

--- a/src/use-lazy-load/lazy-load-controller.ts
+++ b/src/use-lazy-load/lazy-load-controller.ts
@@ -5,11 +5,14 @@ export class LazyLoadController extends Controller {
   isLoading: boolean = false
   isLoaded: boolean = false
   options: IntersectionObserverInit = { rootMargin: '10%' }
+  observe!: () => void
+  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
     requestAnimationFrame(() => {
-      useLazyLoad(this, this.options)
+      const [observe, unobserve] = useLazyLoad(this, this.options)
+      Object.assign(this, { observe, unobserve })
     })
   }
 

--- a/src/use-lazy-load/useLazyLoad.ts
+++ b/src/use-lazy-load/useLazyLoad.ts
@@ -30,22 +30,27 @@ export const useLazyLoad = (controller: LazyLoadController, options?: Intersecti
   }
 
   // keep a copy of the current disconnect() function of the controller to not override it
-  const controllerDisconnect = controller.disconnect
+  const controllerDisconnect = controller.disconnect.bind(controller)
+
+  const observer = new IntersectionObserver(callback, options)
+
+  const observe = () => {
+    observer.observe(controller.element)
+  }
+
+  const unobserve = () => {
+    observer.unobserve(controller.element)
+  }
 
   Object.assign(controller, {
     isVisible: false,
-    observer: new IntersectionObserver(callback, options),
-    observe() {
-      this.observer.observe(controller.element)
-    },
-    unObserve() {
-      this.observer.unobserve(controller.element)
-    },
     disconnect() {
-      controller.unObserve()
+      unobserve()
       controllerDisconnect()
     },
   })
 
-  controller.observe()
+  observe()
+
+  return [observe, unobserve] as const
 }

--- a/src/use-resize/resize-controller.ts
+++ b/src/use-resize/resize-controller.ts
@@ -2,7 +2,6 @@ import { Controller, Context } from 'stimulus'
 import { useResize, ResizeOptions } from './use-resize'
 
 export class ResizeController extends Controller {
-  observer!: ResizeObserver
   options: ResizeOptions = {}
 
   constructor(context: Context) {
@@ -11,10 +10,6 @@ export class ResizeController extends Controller {
       useResize(this, this.options)
     })
   }
-
-  observe() {}
-
-  unObserve() {}
 
   resize(contentRect: DOMRectReadOnly) {}
 }

--- a/src/use-resize/resize-controller.ts
+++ b/src/use-resize/resize-controller.ts
@@ -3,11 +3,14 @@ import { useResize, ResizeOptions } from './use-resize'
 
 export class ResizeController extends Controller {
   options: ResizeOptions = {}
+  observe!: () => void
+  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
     requestAnimationFrame(() => {
-      useResize(this, this.options)
+      const [observe, unobserve] = useResize(this, this.options)
+      Object.assign(this, { observe, unobserve })
     })
   }
 

--- a/src/use-resize/use-resize.ts
+++ b/src/use-resize/use-resize.ts
@@ -33,19 +33,23 @@ export const useResize = (controller: ResizeController, options: ResizeOptions =
 
   const controllerDisconnect = controller.disconnect.bind(controller)
 
+  const observer = new ResizeObserver(callback)
+
+  const observe = () => {
+    observer.observe(targetElement)
+  }
+  const unobserve = () => {
+    observer.unobserve(targetElement)
+  }
+
   Object.assign(controller, {
-    observer: new ResizeObserver(callback),
-    observe() {
-      this.observer.observe(targetElement)
-    },
-    unObserve() {
-      this.observer.unobserve(targetElement)
-    },
     disconnect() {
-      controller.unObserve()
+      unobserve()
       controllerDisconnect()
     },
   })
 
-  controller.observe()
+  observe()
+
+  return [observe, unobserve] as const
 }


### PR DESCRIPTION
fix #45 

Rather than assigning `observe` and `unobserve` to the controller this PR modifies the global API for observer mixins.

The mixin now returns the observe and unobserve function if needed

```js
const [observe, unobserve] = useResize(this, options)
```

The default controller for each mixin also have these default function assigned



