### PR TITLE
Extract useDispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ yarn
 yarn add stimulus-use
 ```
 
-## Modules and Controllers
+## Mixins
 
-- **Observers**
+### Observers
 
   This set of mixins is built around the [`Observer APIs`](https://developer.mozilla.org/en-US/docs/Web/API) and custom events to enhance your controllers with new behaviors.
 
@@ -56,7 +56,7 @@ yarn add stimulus-use
   |[`useResize`](./docs/use-resize.md)|Tracks the element's size and adds a new lifecyle callback **resize**.|`resize`|
   |[`useWindowResize`](./docs/use-window-size.md)| Tracks the size of the `window` object and adds a new lifecyle callback **windowResize**.|`windowResize`|
 
-- **Optimization**
+### Optimization
 
   A set of mixin to optimize performances.
 
@@ -67,33 +67,19 @@ yarn add stimulus-use
   |[`useThrottle`](./docs/use-throttle.md)|Adds the ability to specify an array "throttles" of functions to throttle.|
 
 
-- **Application**
-  - [`useApplication, ApplicationController`](./docs/application-controller.md) &mdash; supercharged controller for your application.
+### Application
+  | Mixin| Description |
+  |[`useApplication, ApplicationController`](./docs/application-controller.md)| supercharged controller for your application.|
+  |[`useDispatch`](./docs/use-dispatch.md)|Adds a dispatch helper function to emit custom events. Useful to communicate between different controllers.|
 
 
 ## Extend or compose
 
-Stimulus-use can be used in two ways: **extending** or **composing**
+Stimulus-use can be used in two ways:  **composing* with mixins* or **extending built-in controllers**
 
-**Extending**
+**Composing with mixins**
 
-You can create your Stimulus controller from a pre-built Stimulus-use controller which offers the new behavior you're looking for.
-This method works perfectly when you only need a single behavior for your controller.
-
-```js
-import { IntersectionController } from 'stimulus-use'
-
-export default class extends IntersectionController {
-  appear(entry) {
-    // triggered when the element appears within the viewport
-  }
-}
-```
-
-**Composing**
-
-When you need multiple behaviors or you are already extending your controller from another one,
-you can easily add new behavior with the built-in `use` functions.
+This is the prefered approach as it bring the most flexibility. Simply import a mixin and apply it in the `connect` or `initialize` to adds new behaviors to you controller. You can combine several mixins within the same controller.
 
 ```js
 import { Controller } from 'stimulus'
@@ -115,29 +101,22 @@ export default class extends Controller {
 }
 ```
 
-## Launch a local playground
+**Extending built-in controllers**
 
-Play with Stimulus-use controllers locally before adding them to one of your projects.
+You can create your Stimulus controller from a pre-built Stimulus-use controller which offers the new behavior you're looking for.
+This method works perfectly when you only need a single behavior for your controller.
 
-Fork and clone the repo (SSH):
-```bash
-git clone git@github.com:stimulus-use/stimulus-use.git
+```js
+import { IntersectionController } from 'stimulus-use'
+
+export default class extends IntersectionController {
+  appear(entry) {
+    // triggered when the element appears within the viewport
+  }
+}
 ```
 
-Once in your local stimulus-use directory, run:
-```bash
-yarn install
-```
 
-Then, build the library locally
-```bash
-yarn build
-```
-
-Launch the playground locally (available at http://localhost:8080/ by default):
-```bash
-yarn start
-```
 
 ## Contributors ✨
 
@@ -177,12 +156,3 @@ Continuous integration and cross browser testing is generously provided Sauce La
 
 [![Testing Powered By SauceLabs](https://opensource.saucelabs.com/images/opensauce/powered-by-saucelabs-badge-white.png?sanitize=true "Testing Powered By SauceLabs")](https://saucelabs.com)
 
-## 🚧 in construction
-
-matrix
-
-[![Sauce Test Status](https://app.saucelabs.com/browser-matrix/adrienpoly.svg)](https://app.saucelabs.com/u/adrienpoly)
-
-badge
-
-[![Sauce Test Status](https://app.saucelabs.com/buildstatus/YOUR_SAUCE_USERNAME)](https://app.saucelabs.com/u/adrienpoly)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,9 +3,7 @@
 * [Usage](usage.md)
 * [Events](events.md)
 
-<br />
-
-* [Observers](observers.md)
+* [**Observers**](observers.md)
   * [useClickOutside](use-click-outside.md)
   * [useIdle](use-idle.md)
   * [useIntersection](use-intersection.md)
@@ -13,15 +11,13 @@
   * [useVisibility](use-visibility.md)
   * [useWindowResize](use-window-resize.md)
 
-<br />
-
-* [Optimization](optimization.md)
+* [**Optimization**](optimization.md)
   * [useDebounce](use-debounce.md)
   * [useMemo](use-memo.md)
   * [useThrottle](use-throttle.md)
 
-<br />
-
-* Application
+* [**Application**](application.md)
   * [useApplication](application-controller.md)
+  * [useDispatch](use-dispatch.md)
+* [Playground](stu-playground.md)
 

--- a/docs/application.md
+++ b/docs/application.md
@@ -1,0 +1,8 @@
+## Application
+
+Mixin and controllers
+
+| Mixin| Description |
+|------|-------------|
+|[`useApplication`](./docs/application-controller.md)|a super charged application controller|
+|[`useDispatch`](./docs/use-dispatch.md)|Adds a dispatch helper function to emit custom events. Useful to communicate between different controllers.|

--- a/docs/application.md
+++ b/docs/application.md
@@ -1,6 +1,6 @@
 ## Application
 
-Mixin and controllers
+Global mixinw and controllers to enhance your application controller.
 
 | Mixin| Description |
 |------|-------------|

--- a/docs/stu-playground.md
+++ b/docs/stu-playground.md
@@ -1,0 +1,24 @@
+## Launch a local playground
+
+
+Play with Stimulus-use controllers locally before adding them to one of your projects.
+
+Fork and clone the repo (SSH):
+```bash
+git clone git@github.com:stimulus-use/stimulus-use.git
+```
+
+Once in your local stimulus-use directory, run:
+```bash
+yarn install
+```
+
+Then, build the library locally
+```bash
+yarn build
+```
+
+Launch the playground locally (available at http://localhost:8080/ by default):
+```bash
+yarn start
+```

--- a/docs/use-dispatch.md
+++ b/docs/use-dispatch.md
@@ -1,0 +1,138 @@
+# useDispatch
+
+Adds a `dispatch` helper function to emit custom events. Useful to communicate between different controllers.
+
+## Reference
+
+#### Mixin
+
+```js
+useDispatch(controller, options = {})
+```
+
+**controller** : a Stimulus Controller (usually `'this'`)
+
+**options** :
+
+| Option| Description |&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Default value&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;|
+|-----------------------|-------------|---------------------|
+| `element` | The element the event will be emitted from.| The controller element|
+| `eventPrefix` | Whether to prefix or not the emitted event. Can be a **boolean** or a **string**.<br>- **true** prefix the event with the controller identifier `item:add` <br>- **someString** prefix the event with the given string `someString:add` <br>- **false** to remove prefix  |true|
+| `bubbles` | Whether the event should bubble.| true|
+| `cancelable` | Whether the event is cancelable.| true|
+
+
+
+#### The dispatch function
+Once the useDispatch mixin is applied, your controller has a new `this.dispatch` function available you may use to emit custom events.
+
+```js
+dispatch(eventName, detail = {})
+```
+| Param| Description |
+|-----------------------|-------------|
+| `eventName` | a mandatory string for the name of the event to emit.|
+| `detail` | A payload object that will be passed to throught the event and available for the receiver with `event.detail` |
+
+## Usage
+
+```js
+// item_controller.js
+import { Controller } from 'stimulus'
+import { useDispatch } from 'stimulus-use'
+
+export default class extends Controller {
+  connect() {
+    usedispatch(this)
+  }
+
+  add() {
+    // dispatch a custom event item:add
+    this.dispatch("add")
+  }
+}
+```
+
+## Bubbling events
+
+The emitted event sent by the `dispatch` function will bubble up the tree of the DOM.
+Therefore all parent elements can listen to it directly.
+
+```html
+<div data-controller="reciever" data-action="emitter:add->reciever#update">
+  <div data-controller="emitter" data-action="click->emitter#add" ></div>
+</div>
+```
+
+If both are at the same level or if the reciever controller is even nested within the controller, you should listen to event with @window to catch it.
+
+```html
+<div data-controller="reciever" data-action="emitter:add@window->reciever#update"></div>
+<div data-controller="emitter" data-action="click->emitter#add" ></div>
+```
+
+## Example building a cart counter with the dispatch helper
+
+The HTML markup. See the custom event `item:add` that the cart controller is listening to
+
+```html
+<div data-controller="cart"
+     data-action="item:add->cart#refreshTotal"
+     data-cart-counter="0">
+
+  <button data-controller="item" data-action="item#add">
+    Add
+  </button>
+
+  <div>
+    <span>No of items : </span>
+    <span data-target="cart.counterView">0</span>
+  </div>
+</div>
+```
+
+The item controller dispatching the event
+
+```js
+//item_controller.js
+import { useDispatch } from 'stimulus-use'
+
+export default class extends Controller {
+  connect() {
+    usedispatch(this)
+  }
+
+  add() {
+    this.dispatch('add', { quantity: 1 })
+  }
+}
+```
+
+The cart controller receiving the event
+
+```js
+//cart_controller.js
+import { ApplicationController } from 'stimulus-use'
+
+export default class extends ApplicationController {
+  static targets = ['counterView']
+
+  refreshTotal(e) {
+    this.counter += e.detail.quantity
+    console.log(e.detail.controller) // the emitting item_controller
+  }
+
+  renderCounter() {
+    this.counterViewTarget.textContent = this.counter
+  }
+
+  set counter(value) {
+    this.data.set('counter', value)
+    this.renderCounter()
+  }
+
+  get counter() {
+    return this.data.get('counter')
+  }
+}
+```

--- a/playground/controllers/cart_controller.js
+++ b/playground/controllers/cart_controller.js
@@ -2,10 +2,11 @@ import { ApplicationController } from 'stimulus-use'
 
 export default class extends ApplicationController {
   static targets = ['counterView']
+  counter = 0
 
   refreshTotal(e) {
-    this.counter++
-    console.log(e.detail.controller)
+    this.counter += e.detail.quantity
+    console.log(e.detail)
   }
 
   renderCounter() {
@@ -18,6 +19,6 @@ export default class extends ApplicationController {
   }
 
   get counter() {
-    return this.data.get('counter')
+    return parseInt(this.data.get('counter'))
   }
 }

--- a/playground/controllers/item_controller.js
+++ b/playground/controllers/item_controller.js
@@ -1,13 +1,20 @@
-import { ApplicationController, useDebounce } from 'stimulus-use'
+import { Controller } from 'stimulus'
+import { useDispatch, useDebounce } from 'stimulus-use'
 
-export default class extends ApplicationController {
+export default class extends Controller {
   static debounces = ['add']
 
   connect() {
-    useDebounce(this)
+    useDebounce(this, { wait: 100 })
+    useDispatch(this)
   }
 
   add() {
-    this.dispatch('add', { detail: { quantity: 1 } })
+    const { id } = this
+    this.dispatch('add', { quantity: 1, id })
+  }
+
+  get id() {
+    return this.data.has('id') ? this.data.get('id') : ''
   }
 }

--- a/spec/fixtures/index-application.html
+++ b/spec/fixtures/index-application.html
@@ -1,4 +1,4 @@
 <!-- fixture -->
-<div data-controller="application" data-action="application:add->application#log" data-id="1">
+<div data-controller="application" data-action="application:add->application#log" data-id="1" id="cart">
   <div data-controller="application" data-action="click->application#count" id="children" data-id="2"></div>
 </div>

--- a/spec/use-application_spec.js
+++ b/spec/use-application_spec.js
@@ -1,6 +1,6 @@
 import { Controller, Application } from 'stimulus'
 import { useApplication, ApplicationController } from '../src'
-import { nextFrame, TestLogger } from './helpers'
+import { nextFrame, TestLogger, click } from './helpers'
 import { expect } from 'chai'
 
 const application = Application.start()
@@ -13,29 +13,32 @@ class LogController extends ApplicationController {
   }
 
   count() {
-    // TODO somehow in Karma environemnt the event does not Bubbles
-    const el = document.querySelector('[data-controller=application]')
-    this.dispatch('add', { target: el, detail: { quantity: 1 } })
+    this.dispatch('add', { quantity: 1 })
   }
 
   get id() {
     return this.element.dataset.id
   }
+
+  get options() {
+    // TODO somehow in Karma environemnt the event does not Bubbles
+    return { element: document.querySelector('#cart') }
+  }
 }
 
 class UseLogController extends Controller {
   initialize() {
-    useApplication(this)
+    // TODO somehow in Karma environemnt the event does not Bubbles
+    const element = document.querySelector('#cart')
+    useApplication(this, { element })
   }
 
   log(e) {
-    testLogger.log({ id: this.id, event: 'dispatch' })
+    testLogger.log({ id: this.id, event: 'dispatch', quantity: e.detail.quantity })
   }
 
   count() {
-    // TODO somehow in Karma environemnt the event does not Bubbles
-    const el = document.querySelector('[data-controller=application]')
-    this.dispatch('add', { target: el, detail: { quantity: 1 } })
+    this.dispatch('add', { quantity: 1 })
   }
 
   get id() {
@@ -56,7 +59,7 @@ controllers.forEach(Controller => {
 
     describe('click dispatch a count ', function () {
       it('parent controller receives the message', async function () {
-        fixture.el.querySelector('#children').click()
+        click('#children')
         await nextFrame()
 
         expect(testLogger.eventsById('1').length).to.equal(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export { useWindowResize, WindowResizeController } from './use-window-resize/ind
 export { useMemo } from './use-memo/index'
 export { useDebounce } from './use-debounce/index'
 export { useThrottle } from './use-throttle/index'
+export { useDispatch } from './use-dispatch/index'

--- a/src/use-application/application-controller.ts
+++ b/src/use-application/application-controller.ts
@@ -1,25 +1,17 @@
 import { Controller, Context } from 'stimulus'
 import { useApplication } from './use-application'
-
-interface EventArgs {
-  target: any
-  detail: any
-  bubbles: boolean
-}
+import { DispatchOptions } from "../use-dispatch"
 
 export class ApplicationController extends Controller {
+  options!: DispatchOptions
+  dispatch!: (eventName: String, detail: any) => void
+  metaValue!: (name: string) => string
   readonly isPreview: boolean = false
   readonly csrfToken: string = ''
 
+
   constructor(context: Context) {
     super(context)
-    useApplication(this)
-  }
-
-  // define function for Typescript but they are overwitten by useApplication
-  dispatch(eventName: String, eventArgs: EventArgs) {}
-
-  metaValue(name: string): string {
-    return ''
+    useApplication(this, this.options)
   }
 }

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -1,6 +1,7 @@
 import { Controller } from 'stimulus'
+import { useDispatch, DispatchOptions } from '../use-dispatch/index'
 
-export const useApplication = (controller: Controller) => {
+export const useApplication = (controller: Controller, options: DispatchOptions) => {
   // getter to detect Turbolink preview
   Object.defineProperty(controller, 'isPreview', {
     get(): boolean {
@@ -15,23 +16,9 @@ export const useApplication = (controller: Controller) => {
     },
   })
 
-  Object.assign(controller, {
-    dispatch(
-      eventName: String,
-      { target = controller.element, detail = {}, bubbles = true, cancelable = true } = {},
-    ): CustomEvent {
-      // include the emitting controller in the event detail
-      Object.assign(detail, { controller })
+  useDispatch(controller, options)
 
-      const type = `${controller.identifier}:${eventName}`
-      const event = new CustomEvent(type, {
-        detail,
-        bubbles,
-        cancelable,
-      })
-      target.dispatchEvent(event)
-      return event
-    },
+  Object.assign(controller, {
     metaValue(name: string) {
       const element = document.head.querySelector(`meta[name="${name}"]`)
       return element && element.getAttribute('content')

--- a/src/use-dispatch/index.ts
+++ b/src/use-dispatch/index.ts
@@ -1,0 +1,1 @@
+export { useDispatch, DispatchOptions } from './use-dispatch'

--- a/src/use-dispatch/use-dispatch.ts
+++ b/src/use-dispatch/use-dispatch.ts
@@ -1,0 +1,42 @@
+import { Controller } from 'stimulus'
+import { composeEventName } from '../support/index'
+
+export interface DispatchOptions {
+  element?: Element
+  eventPrefix?: boolean | string
+  bubbles?: boolean
+  cancelable?: boolean
+}
+
+const defaultOptions = {
+  eventPrefix: true,
+  bubbles: true,
+  cancelable: true
+}
+
+export const useDispatch = (controller: Controller, options?: DispatchOptions) => {
+  const targetElement: Element = options?.element || controller.element
+  const { eventPrefix, bubbles, cancelable } = Object.assign(defaultOptions, options)
+
+  Object.assign(controller, {
+    dispatch(eventName: string, detail = {}): CustomEvent {
+
+      // includes the emitting controller in the event detail
+      Object.assign(detail, { controller })
+
+      const eventNameWithPrefix = composeEventName(eventName, controller, eventPrefix)
+
+      // creates the custom event
+      const event = new CustomEvent(eventNameWithPrefix, {
+        detail,
+        bubbles,
+        cancelable,
+      })
+
+      // dispatch it from the given element or by default from the root element of the controller
+      targetElement.dispatchEvent(event)
+
+      return event
+    }
+  })
+}


### PR DESCRIPTION
`dispatch` function was part of the `ApplicationController` and didn't really get the required visibility.

This PR extract it to it's own mixin

## Usage

```js
// item_controller.js
import { Controller } from 'stimulus'
import { useDispatch } from 'stimulus-use'

export default class extends Controller {
  connect() {
    usedispatch(this)
  }

  add() {
    // dispatch a custom event item:add with a delatil payload of {quantity: 1}
    this.dispatch("add", {quantity: 1})
  }
}
```