### PR TITLE
Fixed homepage link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
       homepage: 'home.md',
       relativePath: true,
       nameLink: '/',
+      basePath: '/stimulus-use/',
       alias: {
         '/docs/(.*)': '/$1',
         'docs/assets/(.*)': 'assets/$1',


### PR DESCRIPTION
Issue: when clicking on the website's project logo/name it goes to a 404. This is because it tries to go to `"/"` instead of `"/stimulus-use/"`. I am not familiar at all with Docsify, but I believe this might be related to [the option `basePath`](https://docsify.js.org/#/configuration?id=basepath).

I haven't been able to actually test it so I don't know if this actually works, please verify it before accepting/merging. I can try to verify it later/tomorrow otherwise.

Context: https://twitter.com/FPresencia/status/1335585928954474499

