### PR TITLE
Avoid overriding defaultOptions directly

### DIFF
--- a/src/use-idle/use-idle.ts
+++ b/src/use-idle/use-idle.ts
@@ -21,7 +21,7 @@ const defaultOptions = {
 }
 
 export const useIdle = (controller: IdleController, options: IdleOptions = {}) => {
-  const { ms, initialState, events, dispatchEvent, eventPrefix } = Object.assign(defaultOptions, options)
+  const { ms, initialState, events, dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
 
   let isIdle = initialState
   let timeout = setTimeout(() => {

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -13,7 +13,7 @@ const defaultOptions = {
 }
 
 export const useIntersection = (controller: IntersectionController, options: IntersectionOptions = {}) => {
-  const { dispatchEvent, eventPrefix } = Object.assign(defaultOptions, options)
+  const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
   const callback = (entries: IntersectionObserverEntry[]) => {

--- a/src/use-resize/use-resize.ts
+++ b/src/use-resize/use-resize.ts
@@ -13,7 +13,7 @@ const defaultOptions = {
 }
 
 export const useResize = (controller: ResizeController, options: ResizeOptions = {}) => {
-  const { dispatchEvent, eventPrefix } = Object.assign(defaultOptions, options)
+  const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
   const callback = (entries: ResizeObserverEntry[]) => {

--- a/src/use-visibility/use-visibility.ts
+++ b/src/use-visibility/use-visibility.ts
@@ -17,7 +17,7 @@ export class UseVisibility {
   dispatchEvent!: boolean
 
   constructor(controller: VisibilityController, options: VisibilityOptions = {}) {
-    const { dispatchEvent, eventPrefix } = Object.assign(defaultOptions, options)
+    const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
     Object.assign(this, { dispatchEvent, eventPrefix })
 
     this.controller = controller


### PR DESCRIPTION
When calculating options using defaultOptions, the first argument of Object.assign should be {}.
Otherwise the defaultOptions itself would be rewritten.

Thanks for maintaining a great product!
