### PR TITLE
fix click outside for partially visible element

### DIFF
--- a/docs/use-click-outside.md
+++ b/docs/use-click-outside.md
@@ -18,7 +18,7 @@ useClickOutside(controller, options = {})
 | `element` | The root element listening for outside click.| The controller element|
 |`eventPrefix`| Whether to prefix or not the emitted event. Can be a **boolean** or a **string**.<br>- **true** prefix the event with the controller identifier `card:click:outside` <br>- **someString** prefix the event with the given string `someString:click:outside` <br>- **false** to remove prefix  |true|
 | `events` | Array of events to listen on to detect if the user clicks outside of the component.| `['click', 'touchend']` |
-| `onlyVisible` | Triggers click outside only to elements that are visible with in the viewport.| `true` |
+| `onlyVisible` | Triggers click outside only to elements that are partially visible with in the viewport.| `true` |
 
 **Example :**
 

--- a/spec/use-click-outside/fixtures.js
+++ b/spec/use-click-outside/fixtures.js
@@ -11,6 +11,19 @@ export const fixtureBase = `
   </div>
 `
 
+export const fixturePartiallyVisible = `
+  <div style="height: 95vh;" id="outside-1"></div>
+  <div data-controller="modal" id="modal-1" data-action="modal:click:outside->modal#close click:outside->modal#close" data-id="1">
+    <button style="height: 10vh;" id="inside-1"></button>
+  </div>
+
+  <div style="height: 120vh;"></div>
+  <button id="outside-2"></button>
+  <div data-controller="modal" data-action="modal:click:outside->modal#close" data-id="2">
+    <button style="height: 10vh;" id="inside-2"></button>
+  </div>
+`
+
 export const fixtureCustomPrefix = `
   <div style="height: 10vh;" id="outside-1"></div>
   <div data-controller="modal" id="modal-1" data-action="custom:click:outside->modal#close" data-id="1">

--- a/spec/use-click-outside/use-click-outside_spec.js
+++ b/spec/use-click-outside/use-click-outside_spec.js
@@ -3,7 +3,7 @@ import { nextFrame, TestLogger, click, remove } from '../helpers'
 import { expect } from 'chai'
 import LogController from './log_controller'
 import UseLogController from './use_log_controller'
-import { fixtureBase, fixtureCustomPrefix, fixtureWithoutPrefix } from './fixtures'
+import { fixtureBase, fixtureCustomPrefix, fixtureWithoutPrefix, fixturePartiallyVisible } from './fixtures'
 
 const controllers = [
   {
@@ -72,6 +72,16 @@ const scenarios = [
       eventCount: 0,
       callbackCounts: 0
     }
+  },
+  {
+    name: 'partially visible element',
+    fixture: fixturePartiallyVisible,
+    options: {},
+    answers: {
+      eventCount: 1,
+      callbackCounts: 1,
+      eventName: 'modal:click:outside'
+    }
   }
 ]
 
@@ -96,11 +106,9 @@ scenarios.forEach(scenario => {
       })
 
       describe(`clicking outside and inside of the div`, function () {
-        before('perform the clicks', async function () {
-          click('#outside-1')
-          click('#inside-1')
-        })
         it('it triggers the outsideClick function', async function () {
+          await click('#outside-1')
+          await click('#inside-1')
           expect(
             testLogger.eventsFilter({
               id: ['1'],
@@ -119,20 +127,15 @@ scenarios.forEach(scenario => {
       })
 
       describe(`clicking outside invisible div`, async function () {
-        before('perform the clicks', function () {
-          click('#outside-1')
-        })
-        it('it triggers the outsideClick function', function () {
+        it('it triggers the outsideClick function', async function () {
+          await click('#outside-1')
           expect(testLogger.eventsFilter({ id: ['2'], event: ['clickOutside', 'click:outside'] }).length).to.equal(0)
         })
       })
 
       describe(`Preserve connect and disconnect lifecycles`, async function () {
-        before('perform a full lifecycle', async function () {
-          click('#outside-1')
-          await remove('#modal-1')
-        })
         it('initialize connect and disconnect are recorded with this context', async function () {
+          await remove('#modal-1')
           expect(testLogger.eventsFilter({ id: ['1'], event: ['initialize'] }).length).to.equal(1)
           expect(testLogger.eventsFilter({ id: ['1'], event: ['connect'] }).length).to.equal(1)
           expect(testLogger.eventsFilter({ id: ['1'], event: ['disconnect'] }).length).to.equal(1)

--- a/src/support/index.ts
+++ b/src/support/index.ts
@@ -34,13 +34,15 @@ export const extendedEvent = (type: string, event: Event | null, detail: object)
   return customEvent
 }
 
-export const isElementInViewport = (el: Element): boolean => {
-  const rect = el.getBoundingClientRect()
+export function isElementInViewport(el: Element) {
+  const rect = el.getBoundingClientRect();
 
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  )
+  const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
+  const windowWidth = (window.innerWidth || document.documentElement.clientWidth);
+
+  const vertInView = (rect.top <= windowHeight) && ((rect.top + rect.height) >= 0);
+  const horInView = (rect.left <= windowWidth) && ((rect.left + rect.width) >= 0);
+
+  return (vertInView && horInView);
 }
+


### PR DESCRIPTION
closes #103 

as reported in #103 click outside callback would not trigger if the element is partially in the view port. This was not the intended behavior. Only element completely outside the viewport should not trigger a callback is the option onlyVisible is set to true.