### PR TITLE
Fix typing information for pre-declared methods that are added by the enhancement functions

### DIFF
--- a/src/support/index.ts
+++ b/src/support/index.ts
@@ -4,8 +4,9 @@ export const method = (controller: Controller, methodName: string): Function => 
   const method = (controller as any)[methodName]
   if (typeof method == 'function') {
     return method
+  } else {
+    return (...args: any[]) => {}
   }
-  throw new Error(`undefined method "${methodName}"`)
 }
 
 export const composeEventName = (name: string, controller: Controller, eventPrefix: boolean | string) => {
@@ -35,14 +36,14 @@ export const extendedEvent = (type: string, event: Event | null, detail: object)
 }
 
 export function isElementInViewport(el: Element) {
-  const rect = el.getBoundingClientRect();
+  const rect = el.getBoundingClientRect()
 
-  const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
-  const windowWidth = (window.innerWidth || document.documentElement.clientWidth);
+  const windowHeight = (window.innerHeight || document.documentElement.clientHeight)
+  const windowWidth = (window.innerWidth || document.documentElement.clientWidth)
 
-  const vertInView = (rect.top <= windowHeight) && ((rect.top + rect.height) >= 0);
-  const horInView = (rect.left <= windowWidth) && ((rect.left + rect.width) >= 0);
+  const vertInView = (rect.top <= windowHeight) && ((rect.top + rect.height) >= 0)
+  const horInView = (rect.left <= windowWidth) && ((rect.left + rect.width) >= 0)
 
-  return (vertInView && horInView);
+  return (vertInView && horInView)
 }
 

--- a/src/use-application/application-controller.ts
+++ b/src/use-application/application-controller.ts
@@ -3,9 +3,7 @@ import { useApplication } from './use-application'
 import { DispatchOptions } from "../use-dispatch"
 
 export class ApplicationController extends Controller {
-  options!: DispatchOptions
-  dispatch!: (eventName: String, detail: any) => void
-  metaValue!: (name: string) => string
+  options?: DispatchOptions
   readonly isPreview: boolean = false
   readonly csrfToken: string = ''
 
@@ -14,4 +12,8 @@ export class ApplicationController extends Controller {
     super(context)
     useApplication(this, this.options)
   }
+
+  declare metaValue: (name: string) => string
+  declare dispatch: (eventName: String, detail: any) => void
+
 }

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -1,7 +1,7 @@
 import { Controller } from 'stimulus'
 import { useDispatch, DispatchOptions } from '../use-dispatch/index'
 
-export const useApplication = (controller: Controller, options: DispatchOptions) => {
+export const useApplication = (controller: Controller, options: DispatchOptions= {}) => {
   // getter to detect Turbolink preview
   Object.defineProperty(controller, 'isPreview', {
     get(): boolean {

--- a/src/use-click-outside/click-outside-controller.ts
+++ b/src/use-click-outside/click-outside-controller.ts
@@ -1,8 +1,11 @@
-import { Controller, Context } from 'stimulus'
-import { useClickOutside, ClickOutsideOptions } from './use-click-outside'
+import { Context, Controller } from 'stimulus'
+import { ClickOutsideOptions, useClickOutside } from './use-click-outside'
 
-export class ClickOutsideController extends Controller {
+export class ClickOutsideComposableController extends Controller {
+  declare clickOutside: (event: Event) => void
+}
 
+export class ClickOutsideController extends ClickOutsideComposableController {
   options?: ClickOutsideOptions
 
   constructor(context: Context) {
@@ -13,8 +16,6 @@ export class ClickOutsideController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare clickOutside: (event: Event) => void
-
+  declare observe: () => void
+  declare unobserve: () => void
 }

--- a/src/use-click-outside/click-outside-controller.ts
+++ b/src/use-click-outside/click-outside-controller.ts
@@ -2,9 +2,8 @@ import { Controller, Context } from 'stimulus'
 import { useClickOutside, ClickOutsideOptions } from './use-click-outside'
 
 export class ClickOutsideController extends Controller {
-  options!: ClickOutsideOptions
-  observe!: () => void
-  unobserve!: () => void
+
+  options?: ClickOutsideOptions
 
   constructor(context: Context) {
     super(context)
@@ -14,5 +13,8 @@ export class ClickOutsideController extends Controller {
     })
   }
 
-  clickOutside(event: Event) {}
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare clickOutside: (event: Event) => void
+
 }

--- a/src/use-click-outside/use-click-outside.ts
+++ b/src/use-click-outside/use-click-outside.ts
@@ -20,7 +20,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useClickOutside = (controller: ClickOutsideController, options: ClickOutsideOptions = {}) => {
+export const useClickOutside = (controller: Omit<ClickOutsideController, "options"|"observe"|"unobserve">, options: ClickOutsideOptions = {}) => {
   const { onlyVisible, dispatchEvent, events, eventPrefix } = Object.assign({}, defaultOptions, options)
 
   const onEvent = (event: Event) => {

--- a/src/use-click-outside/use-click-outside.ts
+++ b/src/use-click-outside/use-click-outside.ts
@@ -1,9 +1,5 @@
-import { Controller } from 'stimulus'
-import { method, extendedEvent, isElementInViewport, composeEventName } from '../support/index'
-
-interface ClickOutsideController extends Controller {
-  clickOutside?: (event: Event) => void
-}
+import { composeEventName, extendedEvent, isElementInViewport } from '../support/index'
+import { ClickOutsideComposableController } from './click-outside-controller'
 
 export interface ClickOutsideOptions {
   element?: Element
@@ -20,7 +16,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useClickOutside = (controller: Omit<ClickOutsideController, "options"|"observe"|"unobserve">, options: ClickOutsideOptions = {}) => {
+export const useClickOutside = (controller: ClickOutsideComposableController, options: ClickOutsideOptions = {}) => {
   const { onlyVisible, dispatchEvent, events, eventPrefix } = Object.assign({}, defaultOptions, options)
 
   const onEvent = (event: Event) => {
@@ -31,7 +27,9 @@ export const useClickOutside = (controller: Omit<ClickOutsideController, "option
     }
 
     // call the clickOutside method of the Stimulus controller
-    controller.clickOutside && method(controller, 'clickOutside').call(controller, event)
+    if (controller.clickOutside) {
+      controller.clickOutside(event)
+    }
 
     // emit a custom event
     if (dispatchEvent) {

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -12,14 +12,16 @@ class DebounceController extends Controller {
 const defaultWait = 200
 
 const debounce = (fn: Function, wait: number = defaultWait) => {
-  let timeoutId: NodeJS.Timeout | number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
 
   return function (this: any): any {
     const args = arguments;
     const context = this;
 
     const callback = () => fn.apply(context, args)
-    clearTimeout(<number>timeoutId)
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
     timeoutId = setTimeout(callback, wait)
   }
 }

--- a/src/use-hover/hover-controller.ts
+++ b/src/use-hover/hover-controller.ts
@@ -2,7 +2,7 @@ import { Context, Controller } from 'stimulus'
 import { HoverOptions, useHover } from './use-hover'
 
 export class HoverController extends Controller {
-  options!: HoverOptions
+  options?: HoverOptions
 
   constructor(context: Context) {
     super(context)
@@ -12,9 +12,9 @@ export class HoverController extends Controller {
     })
   }
 
-  observe!: () => {}
-  unobserve!: () => {}
+  declare observe?: () => void;
+  declare unobserve?: () => void;
+  declare mouseEnter?: () => void;
+  declare mouseLeave?: () => void;
 
-  mouseEnter!: () => {}
-  mouseLeave!: () => {}
 }

--- a/src/use-hover/hover-controller.ts
+++ b/src/use-hover/hover-controller.ts
@@ -1,7 +1,11 @@
 import { Context, Controller } from 'stimulus'
 import { HoverOptions, useHover } from './use-hover'
 
-export class HoverController extends Controller {
+export class HoverComposableController extends Controller {
+  declare mouseEnter?: () => void;
+  declare mouseLeave?: () => void;
+}
+export class HoverController extends HoverComposableController {
   options?: HoverOptions
 
   constructor(context: Context) {
@@ -12,9 +16,6 @@ export class HoverController extends Controller {
     })
   }
 
-  declare observe?: () => void;
-  declare unobserve?: () => void;
-  declare mouseEnter?: () => void;
-  declare mouseLeave?: () => void;
-
+  declare observe: () => void;
+  declare unobserve: () => void;
 }

--- a/src/use-hover/use-hover.ts
+++ b/src/use-hover/use-hover.ts
@@ -1,16 +1,16 @@
 import { StimulusUse, StimulusUseOptions } from '../stimulus_use'
 import { method } from '../support/index'
-import { HoverController } from './hover-controller'
+import { HoverComposableController, HoverController } from './hover-controller'
 
 export interface HoverOptions extends StimulusUseOptions {
   element?: Element
 }
 
 export class UseHover extends StimulusUse {
-  controller: HoverController
+  controller: HoverComposableController
   targetElement: Element
 
-  constructor(controller: HoverController, options: HoverOptions = {}) {
+  constructor(controller: HoverComposableController, options: HoverOptions = {}) {
     super(controller, options)
     this.targetElement = options?.element || controller.element
     this.controller = controller
@@ -29,12 +29,12 @@ export class UseHover extends StimulusUse {
   }
 
   private onEnter = () => {
-    this.controller.mouseEnter && method(this.controller, 'mouseEnter').call(this.controller)
+    method(this.controller, 'mouseEnter').call(this.controller)
     this.log('mouseEnter', { hover: true })
   }
 
   private onLeave = () => {
-    this.controller.mouseLeave && method(this.controller, 'mouseLeave').call(this.controller)
+    method(this.controller, 'mouseLeave').call(this.controller)
     this.log('mouseLeave', { hover: false })
   }
 
@@ -50,7 +50,7 @@ export class UseHover extends StimulusUse {
   }
 }
 
-export const useHover = (controller: Omit<HoverController, 'options' | 'observe' | 'unobserve'>, options: HoverOptions = {}) => {
+export const useHover = (controller: HoverComposableController, options: HoverOptions = {}) => {
   const observer = new UseHover(controller, options)
   return [observer.observe, observer.unobserve] as const
 }

--- a/src/use-hover/use-hover.ts
+++ b/src/use-hover/use-hover.ts
@@ -50,7 +50,7 @@ export class UseHover extends StimulusUse {
   }
 }
 
-export const useHover = (controller: HoverController, options: HoverOptions = {}) => {
+export const useHover = (controller: Omit<HoverController, 'options' | 'observe' | 'unobserve'>, options: HoverOptions = {}) => {
   const observer = new UseHover(controller, options)
   return [observer.observe, observer.unobserve] as const
 }

--- a/src/use-idle/idle-controller.ts
+++ b/src/use-idle/idle-controller.ts
@@ -1,8 +1,13 @@
 import { Controller, Context } from 'stimulus'
-import { useIdle, IdleOptions } from './use-idle'
+import { IdleOptions, useIdle } from './use-idle'
 
-export class IdleController extends Controller {
+export class IdleComposableController extends Controller {
   isIdle: boolean = false
+  declare away: () => void
+  declare back: () => void
+}
+
+export class IdleController extends IdleComposableController {
   options?: IdleOptions
 
   constructor(context: Context) {
@@ -13,9 +18,7 @@ export class IdleController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare away: () => void
-  declare back: () => void
+  declare observe: () => void
+  declare unobserve: () => void
 
 }

--- a/src/use-idle/idle-controller.ts
+++ b/src/use-idle/idle-controller.ts
@@ -3,9 +3,7 @@ import { useIdle, IdleOptions } from './use-idle'
 
 export class IdleController extends Controller {
   isIdle: boolean = false
-  options!: IdleOptions
-  observe!: () => void
-  unobserve!: () => void
+  options?: IdleOptions
 
   constructor(context: Context) {
     super(context)
@@ -15,7 +13,9 @@ export class IdleController extends Controller {
     })
   }
 
-  away() {}
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare away: () => void
+  declare back: () => void
 
-  back() {}
 }

--- a/src/use-idle/use-idle.ts
+++ b/src/use-idle/use-idle.ts
@@ -20,7 +20,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useIdle = (controller: IdleController, options: IdleOptions = {}) => {
+export const useIdle = (controller: Omit<IdleController, "options"|"observe"|"unobserve">, options: IdleOptions = {}) => {
   const { ms, initialState, events, dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
 
   let isIdle = initialState

--- a/src/use-idle/use-idle.ts
+++ b/src/use-idle/use-idle.ts
@@ -1,4 +1,4 @@
-import { IdleController } from './idle-controller'
+import { IdleComposableController, IdleController } from './idle-controller'
 import { extendedEvent, method, composeEventName } from '../support/index'
 
 const defaultEvents = ['mousemove', 'mousedown', 'resize', 'keydown', 'touchstart', 'wheel']
@@ -20,7 +20,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useIdle = (controller: Omit<IdleController, "options"|"observe"|"unobserve">, options: IdleOptions = {}) => {
+export const useIdle = (controller: IdleComposableController, options: IdleOptions = {}) => {
   const { ms, initialState, events, dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
 
   let isIdle = initialState
@@ -33,7 +33,7 @@ export const useIdle = (controller: Omit<IdleController, "options"|"observe"|"un
     const eventName = composeEventName('away', controller, eventPrefix)
 
     controller.isIdle = true
-    controller.away && method(controller, 'away').call(controller, event)
+    method(controller, 'away').call(controller, event)
 
     if (dispatchEvent) {
       const clickOutsideEvent = extendedEvent(eventName, event || null, { controller })
@@ -45,7 +45,7 @@ export const useIdle = (controller: Omit<IdleController, "options"|"observe"|"un
     const eventName = composeEventName('back', controller, eventPrefix)
 
     controller.isIdle = false
-    controller.back && method(controller, 'back').call(controller, event)
+    method(controller, 'back').call(controller, event)
 
     if (dispatchEvent) {
       const clickOutsideEvent = extendedEvent(eventName, event || null, { controller })

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -3,11 +3,7 @@ import { useIntersection, IntersectionOptions } from './use-intersection'
 
 export class IntersectionController extends Controller {
   isVisible: boolean = false
-  options!: IntersectionOptions
-  observe!: () => void
-  unobserve!: () => void
-  appear!: (entry: IntersectionObserverEntry) => void
-  disappear!: (entry: IntersectionObserverEntry) => void
+  options?: IntersectionOptions
 
   constructor(context: Context) {
     super(context)
@@ -16,4 +12,10 @@ export class IntersectionController extends Controller {
       Object.assign(this, { observe, unobserve })
     })
   }
+
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare appear: (entry: IntersectionObserverEntry) => void
+  declare disappear: (entry: IntersectionObserverEntry) => void
+
 }

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -1,8 +1,13 @@
 import { Controller, Context } from 'stimulus'
 import { useIntersection, IntersectionOptions } from './use-intersection'
 
-export class IntersectionController extends Controller {
+export class IntersectionComposableController extends Controller {
   isVisible: boolean = false
+  declare appear?: (entry: IntersectionObserverEntry) => void
+  declare disappear?: (entry: IntersectionObserverEntry) => void
+}
+
+export class IntersectionController extends IntersectionComposableController {
   options?: IntersectionOptions
 
   constructor(context: Context) {
@@ -13,9 +18,7 @@ export class IntersectionController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare appear: (entry: IntersectionObserverEntry) => void
-  declare disappear: (entry: IntersectionObserverEntry) => void
+  declare observe: () => void
+  declare unobserve: () => void
 
 }

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -12,7 +12,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useIntersection = (controller: IntersectionController, options: IntersectionOptions = {}) => {
+export const useIntersection = (controller: Omit<IntersectionController, "options"|"observe"|"unobserve">, options: IntersectionOptions = {}) => {
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -1,4 +1,4 @@
-import { IntersectionController } from './intersection-controller'
+import { IntersectionComposableController } from './intersection-controller'
 import { method, extendedEvent, composeEventName } from '../support/index'
 
 export interface IntersectionOptions extends IntersectionObserverInit {
@@ -12,7 +12,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useIntersection = (controller: Omit<IntersectionController, "options"|"observe"|"unobserve">, options: IntersectionOptions = {}) => {
+export const useIntersection = (controller: IntersectionComposableController, options: IntersectionOptions = {}) => {
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
@@ -27,7 +27,7 @@ export const useIntersection = (controller: Omit<IntersectionController, "option
 
   const dispatchAppear = (entry: IntersectionObserverEntry) => {
     controller.isVisible = true
-    controller.appear && method(controller, 'appear').call(controller, entry)
+    method(controller, 'appear').call(controller, entry)
 
     // emit a custom "appear" event
     if (dispatchEvent) {
@@ -40,7 +40,7 @@ export const useIntersection = (controller: Omit<IntersectionController, "option
 
   const dispatchDisappear = (entry: IntersectionObserverEntry) => {
     controller.isVisible = false
-    controller.disappear && method(controller, 'disappear').call(controller, entry)
+    method(controller, 'disappear').call(controller, entry)
 
     // emit a custom "disappear" event
     if (dispatchEvent) {

--- a/src/use-lazy-load/lazy-load-controller.ts
+++ b/src/use-lazy-load/lazy-load-controller.ts
@@ -1,9 +1,14 @@
 import { Controller, Context } from 'stimulus'
 import { useLazyLoad } from './useLazyLoad'
 
-export class LazyLoadController extends Controller {
+export class LazyLoadComposableController extends Controller {
   isLoading: boolean = false
   isLoaded: boolean = false
+  declare loading: (src: string) => void
+  declare loaded: (src: string) => void
+}
+
+export class LazyLoadController extends LazyLoadComposableController {
   options: IntersectionObserverInit = { rootMargin: '10%' }
 
   constructor(context: Context) {
@@ -14,9 +19,7 @@ export class LazyLoadController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare loading: (src: string) => void
-  declare loaded: (src: string) => void
+  declare observe: () => void
+  declare unobserve: () => void
 
 }

--- a/src/use-lazy-load/lazy-load-controller.ts
+++ b/src/use-lazy-load/lazy-load-controller.ts
@@ -5,8 +5,6 @@ export class LazyLoadController extends Controller {
   isLoading: boolean = false
   isLoaded: boolean = false
   options: IntersectionObserverInit = { rootMargin: '10%' }
-  observe!: () => void
-  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
@@ -16,7 +14,9 @@ export class LazyLoadController extends Controller {
     })
   }
 
-  loading(src: string) {}
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare loading: (src: string) => void
+  declare loaded: (src: string) => void
 
-  loaded(src: string) {}
 }

--- a/src/use-lazy-load/useLazyLoad.ts
+++ b/src/use-lazy-load/useLazyLoad.ts
@@ -1,7 +1,7 @@
-import { LazyLoadController } from './lazy-load-controller'
+import { LazyLoadComposableController } from './lazy-load-controller'
 import { method } from '../support/index'
 
-export const useLazyLoad = (controller: Omit<LazyLoadController, "observe"|"unobserve">, options?: IntersectionObserverInit) => {
+export const useLazyLoad = (controller: LazyLoadComposableController, options?: IntersectionObserverInit) => {
   const callback = (entries: IntersectionObserverEntry[]) => {
     const [entry] = entries
     if (entry.isIntersecting && !controller.isLoaded) {
@@ -15,7 +15,7 @@ export const useLazyLoad = (controller: Omit<LazyLoadController, "observe"|"unob
 
     const imageElement = <HTMLImageElement>controller.element
     controller.isLoading = true
-    controller.loading && method(controller, 'loading').call(controller, src)
+    method(controller, 'loading').call(controller, src)
     imageElement.onload = () => {
       handleLoaded(src)
     }
@@ -26,7 +26,7 @@ export const useLazyLoad = (controller: Omit<LazyLoadController, "observe"|"unob
   const handleLoaded = (src: string) => {
     controller.isLoading = false
     controller.isLoaded = true
-    controller.loading && method(controller, 'loaded').call(controller, src)
+    method(controller, 'loaded').call(controller, src)
   }
 
   // keep a copy of the current disconnect() function of the controller to not override it

--- a/src/use-lazy-load/useLazyLoad.ts
+++ b/src/use-lazy-load/useLazyLoad.ts
@@ -1,7 +1,7 @@
 import { LazyLoadController } from './lazy-load-controller'
 import { method } from '../support/index'
 
-export const useLazyLoad = (controller: LazyLoadController, options?: IntersectionObserverInit) => {
+export const useLazyLoad = (controller: Omit<LazyLoadController, "observe"|"unobserve">, options?: IntersectionObserverInit) => {
   const callback = (entries: IntersectionObserverEntry[]) => {
     const [entry] = entries
     if (entry.isIntersecting && !controller.isLoaded) {

--- a/src/use-mutation/mutation-controller.ts
+++ b/src/use-mutation/mutation-controller.ts
@@ -1,7 +1,11 @@
 import { Context, Controller } from 'stimulus'
 import { MutationOptions, useMutation } from './use-mutation'
 
-export class MutationController extends Controller {
+export class MutationComposableController extends Controller {
+  declare mutate: (entries: MutationRecord[]) => void
+}
+
+export class MutationController extends MutationComposableController {
   options?: MutationOptions
 
   constructor(context: Context) {
@@ -12,8 +16,7 @@ export class MutationController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare mutate?: (entries: MutationRecord[]) => void
+  declare observe: () => void
+  declare unobserve: () => void
 
 }

--- a/src/use-mutation/mutation-controller.ts
+++ b/src/use-mutation/mutation-controller.ts
@@ -2,7 +2,7 @@ import { Context, Controller } from 'stimulus'
 import { MutationOptions, useMutation } from './use-mutation'
 
 export class MutationController extends Controller {
-  options!: MutationOptions
+  options?: MutationOptions
 
   constructor(context: Context) {
     super(context)
@@ -12,8 +12,8 @@ export class MutationController extends Controller {
     })
   }
 
-  observe!: () => {}
-  unobserve!: () => {}
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare mutate?: (entries: MutationRecord[]) => void
 
-  mutate!: (entries: MutationRecord[]) => {}
 }

--- a/src/use-mutation/use-mutation.ts
+++ b/src/use-mutation/use-mutation.ts
@@ -15,7 +15,7 @@ export class UseMutation extends StimulusUse {
   targetElement: Element
   options: MutationOptions
 
-  constructor(controller: MutationController, options: MutationOptions = {}) {
+  constructor(controller: Omit<MutationController, "options"|"observe"|"unobserve">, options: MutationOptions = {}) {
     super(controller, options)
 
     this.targetElement = options?.element || controller.element

--- a/src/use-mutation/use-mutation.ts
+++ b/src/use-mutation/use-mutation.ts
@@ -1,6 +1,6 @@
 import { StimulusUse, StimulusUseOptions } from '../stimulus_use'
 import { method } from '../support/index'
-import { MutationController } from './mutation-controller'
+import { MutationComposableController } from './mutation-controller'
 
 export interface MutationControllerOptions {
   element?: Element
@@ -10,12 +10,12 @@ export interface MutationOptions extends MutationObserverInit, MutationControlle
 }
 
 export class UseMutation extends StimulusUse {
-  controller: MutationController
+  controller: MutationComposableController
   observer: MutationObserver
   targetElement: Element
   options: MutationOptions
 
-  constructor(controller: Omit<MutationController, "options"|"observe"|"unobserve">, options: MutationOptions = {}) {
+  constructor(controller: MutationComposableController, options: MutationOptions = {}) {
     super(controller, options)
 
     this.targetElement = options?.element || controller.element
@@ -40,7 +40,7 @@ export class UseMutation extends StimulusUse {
   }
 
   private mutation = (entries: MutationRecord[]) => {
-    this.controller.mutate && method(this.controller, 'mutate').call(this.controller, entries)
+    method(this.controller, 'mutate').call(this.controller, entries)
     this.log('mutate', { entries })
   }
 
@@ -54,7 +54,7 @@ export class UseMutation extends StimulusUse {
   }
 }
 
-export const useMutation = (controller: MutationController, options: MutationOptions = {}) => {
+export const useMutation = (controller: MutationComposableController, options: MutationOptions = {}) => {
   const observer = new UseMutation(controller, options)
   return [observer.observe, observer.unobserve] as const
 }

--- a/src/use-resize/resize-controller.ts
+++ b/src/use-resize/resize-controller.ts
@@ -2,9 +2,7 @@ import { Controller, Context } from 'stimulus'
 import { useResize, ResizeOptions } from './use-resize'
 
 export class ResizeController extends Controller {
-  options!: ResizeOptions
-  observe!: () => void
-  unobserve!: () => void
+  options?: ResizeOptions
 
   constructor(context: Context) {
     super(context)
@@ -14,5 +12,8 @@ export class ResizeController extends Controller {
     })
   }
 
-  resize(contentRect: DOMRectReadOnly) {}
+  declare resize: (contentRect: DOMRectReadOnly) => void
+  declare observe?: () => void
+  declare unobserve?: () => void
+
 }

--- a/src/use-resize/resize-controller.ts
+++ b/src/use-resize/resize-controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Context } from 'stimulus'
 import { useResize, ResizeOptions } from './use-resize'
 
-export class ResizeController extends Controller {
+export class ResizeComposableController extends Controller {
+  declare resize: (contentRect: DOMRectReadOnly) => void
+}
+
+export class ResizeController extends ResizeComposableController {
   options?: ResizeOptions
 
   constructor(context: Context) {
@@ -12,8 +16,6 @@ export class ResizeController extends Controller {
     })
   }
 
-  declare resize: (contentRect: DOMRectReadOnly) => void
-  declare observe?: () => void
-  declare unobserve?: () => void
-
+  declare observe: () => void
+  declare unobserve: () => void
 }

--- a/src/use-resize/use-resize.ts
+++ b/src/use-resize/use-resize.ts
@@ -12,7 +12,7 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useResize = (controller: ResizeController, options: ResizeOptions = {}) => {
+export const useResize = (controller: Omit<ResizeController, "options"|"observe"|"unobserve">, options: ResizeOptions = {}) => {
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 

--- a/src/use-resize/use-resize.ts
+++ b/src/use-resize/use-resize.ts
@@ -1,5 +1,5 @@
-import { ResizeController } from './resize-controller'
-import { method, extendedEvent, composeEventName } from '../support/index'
+import { composeEventName, extendedEvent, method } from '../support/index'
+import { ResizeComposableController } from './resize-controller'
 
 export interface ResizeOptions {
   element?: Element
@@ -12,13 +12,13 @@ const defaultOptions = {
   eventPrefix: true,
 }
 
-export const useResize = (controller: Omit<ResizeController, "options"|"observe"|"unobserve">, options: ResizeOptions = {}) => {
+export const useResize = (controller: ResizeComposableController, options: ResizeOptions = {}) => {
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
   const callback = (entries: ResizeObserverEntry[]) => {
     const [entry] = entries
-    controller.resize && method(controller, 'resize').call(controller, entry.contentRect)
+    method(controller, 'resize').call(controller, entry.contentRect)
 
     // emit a custom "controllerIdentifier:resize" event
     if (dispatchEvent) {

--- a/src/use-throttle/use-throttle.ts
+++ b/src/use-throttle/use-throttle.ts
@@ -26,7 +26,7 @@ export function throttle(func: Function, wait: number = defaultWait): Function {
   };
 }
 
-export const useThrottle = (controller: ThrottleController, options: ThrottleOptions) => {
+export const useThrottle = (controller: ThrottleController, options: ThrottleOptions = {}) => {
   const constructor = controller.constructor as any
 
   constructor.throttles?.forEach((func: string | ThrottleOptions) => {

--- a/src/use-transition/transition-controller.ts
+++ b/src/use-transition/transition-controller.ts
@@ -1,8 +1,15 @@
 import { Controller, Context } from 'stimulus'
 import { useTransition, TransitionOptions } from './use-transition'
 
-export class TransitionController extends Controller {
+export class TransitionComposableController extends Controller {
   transitioned: boolean = false
+
+  declare enter: (event: Event) => void
+  declare leave: (event: Event) => void
+  declare toggleTransition: (event: Event) => void
+}
+
+export class TransitionController extends TransitionComposableController {
   options?: TransitionOptions
 
   constructor(context: Context) {
@@ -11,9 +18,5 @@ export class TransitionController extends Controller {
       useTransition(this, this.options)
     })
   }
-
-  declare enter: (event: Event) => void
-  declare leave: (event: Event) => void
-  declare toggleTransition: (event: Event) => void
 
 }

--- a/src/use-transition/transition-controller.ts
+++ b/src/use-transition/transition-controller.ts
@@ -3,10 +3,7 @@ import { useTransition, TransitionOptions } from './use-transition'
 
 export class TransitionController extends Controller {
   transitioned: boolean = false
-  options!: TransitionOptions
-  enter!: (event: Event) => void
-  leave!: (event: Event) => void
-  toggleTransition!: (event: Event) => void
+  options?: TransitionOptions
 
   constructor(context: Context) {
     super(context)
@@ -14,4 +11,9 @@ export class TransitionController extends Controller {
       useTransition(this, this.options)
     })
   }
+
+  declare enter: (event: Event) => void
+  declare leave: (event: Event) => void
+  declare toggleTransition: (event: Event) => void
+
 }

--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -30,7 +30,7 @@ const defaultOptions = {
   hiddenClass: "hidden"
 }
 
-export const useTransition = (controller: TransitionController, options: TransitionOptions = {}) => {
+export const useTransition = (controller: Omit<TransitionController, "options">, options: TransitionOptions = {}) => {
   const targetName = (controller.element as HTMLElement).dataset.transitionTarget
   let targetFromAttribute
 

--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -1,4 +1,4 @@
-import { TransitionController } from "./transition-controller"
+import { TransitionComposableController, TransitionController } from './transition-controller'
 
 export interface TransitionOptions {
   element?: Element
@@ -30,7 +30,7 @@ const defaultOptions = {
   hiddenClass: "hidden"
 }
 
-export const useTransition = (controller: Omit<TransitionController, "options">, options: TransitionOptions = {}) => {
+export const useTransition = (controller: TransitionComposableController, options: TransitionOptions = {}) => {
   const targetName = (controller.element as HTMLElement).dataset.transitionTarget
   let targetFromAttribute
 

--- a/src/use-visibility/use-visibility.ts
+++ b/src/use-visibility/use-visibility.ts
@@ -1,6 +1,6 @@
-import { extendedEvent, method, composeEventName } from '../support/index'
 import { StimulusUse, StimulusUseOptions } from '../stimulus_use'
-import { VisibilityController } from './visibility-controller'
+import { composeEventName, extendedEvent, method } from '../support/index'
+import { VisibilityComposableController } from './visibility-controller'
 
 export interface VisibilityOptions extends StimulusUseOptions {
   dispatchEvent?: boolean
@@ -9,15 +9,15 @@ export interface VisibilityOptions extends StimulusUseOptions {
 
 const defaultOptions = {
   dispatchEvent: true,
-  eventPrefix: true
+  eventPrefix: true,
 }
 
 export class UseVisibility extends StimulusUse {
-  controller: VisibilityController
+  controller: VisibilityComposableController
   eventPrefix!: boolean | string
   dispatchEvent!: boolean
 
-  constructor(controller: VisibilityController, options: VisibilityOptions = {}) {
+  constructor(controller: VisibilityComposableController, options: VisibilityOptions = {}) {
     super(controller, options)
     const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
     Object.assign(this, { dispatchEvent, eventPrefix })
@@ -51,9 +51,8 @@ export class UseVisibility extends StimulusUse {
     const eventName = composeEventName('invisible', this.controller, this.eventPrefix)
 
     this.controller.isVisible = false
-    this.controller.invisible && method(this.controller, 'invisible').call(this.controller, event)
-
-    this.log("invisible", { isVisible: false })
+    method(this.controller, 'invisible').call(this.controller)
+    this.log('invisible', { isVisible: false })
 
     this.dispatch(eventName, event)
   }
@@ -62,9 +61,8 @@ export class UseVisibility extends StimulusUse {
     const eventName = composeEventName('visible', this.controller, this.eventPrefix)
 
     this.controller.isVisible = true
-    this.controller.visible && method(this.controller, 'visible').call(this.controller, event)
-
-    this.log("visible", { isVisible: true })
+    method(this.controller, 'visible').call(this.controller)
+    this.log('visible', { isVisible: true })
 
     this.dispatch(eventName, event)
   }
@@ -74,7 +72,7 @@ export class UseVisibility extends StimulusUse {
       const detail = { controller: this.controller, isVisible: this.controller.isVisible }
       const visibilityEvent = extendedEvent(eventName, event || null, detail)
       this.controller.element.dispatchEvent(visibilityEvent)
-      this.log("dispatchEvent", { eventName, ...detail })
+      this.log('dispatchEvent', { eventName, ...detail })
     }
   }
 
@@ -87,7 +85,7 @@ export class UseVisibility extends StimulusUse {
   }
 }
 
-export const useVisibility = (controller: Omit<VisibilityController, "options"|"observe"|"unobserve">, options: VisibilityOptions = {}) => {
+export const useVisibility = (controller: VisibilityComposableController, options: VisibilityOptions = {}) => {
   const observer = new UseVisibility(controller, options)
   return [observer.observe, observer.unobserve] as const
 }

--- a/src/use-visibility/use-visibility.ts
+++ b/src/use-visibility/use-visibility.ts
@@ -87,7 +87,7 @@ export class UseVisibility extends StimulusUse {
   }
 }
 
-export const useVisibility = (controller: VisibilityController, options: VisibilityOptions = {}) => {
+export const useVisibility = (controller: Omit<VisibilityController, "options"|"observe"|"unobserve">, options: VisibilityOptions = {}) => {
   const observer = new UseVisibility(controller, options)
   return [observer.observe, observer.unobserve] as const
 }

--- a/src/use-visibility/visibility-controller.ts
+++ b/src/use-visibility/visibility-controller.ts
@@ -1,8 +1,13 @@
 import { Controller, Context } from 'stimulus'
 import { useVisibility, VisibilityOptions } from './use-visibility'
 
-export class VisibilityController extends Controller {
-  isVisible!: boolean
+export class VisibilityComposableController extends Controller {
+  isVisible: boolean = false
+  declare visible?: () => void
+  declare invisible?: () => void
+}
+
+export class VisibilityController extends VisibilityComposableController {
   options?: VisibilityOptions
 
   constructor(context: Context) {
@@ -13,9 +18,7 @@ export class VisibilityController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare visible: () => void
-  declare invisible: () => void
+  declare observe: () => void
+  declare unobserve: () => void
 
 }

--- a/src/use-visibility/visibility-controller.ts
+++ b/src/use-visibility/visibility-controller.ts
@@ -3,11 +3,7 @@ import { useVisibility, VisibilityOptions } from './use-visibility'
 
 export class VisibilityController extends Controller {
   isVisible!: boolean
-  options!: VisibilityOptions
-  observe!: () => void
-  unobserve!: () => void
-  visible!: () => void
-  invisible!: () => void
+  options?: VisibilityOptions
 
   constructor(context: Context) {
     super(context)
@@ -16,4 +12,10 @@ export class VisibilityController extends Controller {
       Object.assign(this, { observe, unobserve })
     })
   }
+
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare visible: () => void
+  declare invisible: () => void
+
 }

--- a/src/use-window-resize/use-window-resize.ts
+++ b/src/use-window-resize/use-window-resize.ts
@@ -7,7 +7,7 @@ export interface WindowResizePayload {
   event?: Event
 }
 
-export const useWindowResize = (controller: WindowResizeController) => {
+export const useWindowResize = (controller: Omit<WindowResizeController, "observe"|"unobserve">) => {
 
   const callback = (event?: Event) => {
     const { innerWidth, innerHeight } = window

--- a/src/use-window-resize/use-window-resize.ts
+++ b/src/use-window-resize/use-window-resize.ts
@@ -1,4 +1,4 @@
-import { WindowResizeController } from './window-resize-controller'
+import { WindowResizeComposableController } from './window-resize-controller'
 import { method } from '../support/index'
 
 export interface WindowResizePayload {
@@ -7,7 +7,7 @@ export interface WindowResizePayload {
   event?: Event
 }
 
-export const useWindowResize = (controller: Omit<WindowResizeController, "observe"|"unobserve">) => {
+export const useWindowResize = (controller: WindowResizeComposableController) => {
 
   const callback = (event?: Event) => {
     const { innerWidth, innerHeight } = window
@@ -18,7 +18,7 @@ export const useWindowResize = (controller: Omit<WindowResizeController, "observ
       event
     }
 
-    controller.windowResize && method(controller, 'windowResize').call(controller, payload)
+    method(controller, 'windowResize').call(controller, payload)
   }
 
   const controllerDisconnect = controller.disconnect.bind(controller)

--- a/src/use-window-resize/window-resize-controller.ts
+++ b/src/use-window-resize/window-resize-controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Context } from 'stimulus'
 import { useWindowResize, WindowResizePayload } from './use-window-resize'
 
-export class WindowResizeController extends Controller {
+export class WindowResizeComposableController extends Controller {
+  declare windowResize: (payload: WindowResizePayload) => void
+}
+
+export class WindowResizeController extends WindowResizeComposableController {
 
   constructor(context: Context) {
     super(context)
@@ -11,8 +15,7 @@ export class WindowResizeController extends Controller {
     })
   }
 
-  declare observe?: () => void
-  declare unobserve?: () => void
-  declare windowResize: (payload: WindowResizePayload) => void
+  declare observe: () => void
+  declare unobserve: () => void
 
 }

--- a/src/use-window-resize/window-resize-controller.ts
+++ b/src/use-window-resize/window-resize-controller.ts
@@ -2,8 +2,6 @@ import { Controller, Context } from 'stimulus'
 import { useWindowResize, WindowResizePayload } from './use-window-resize'
 
 export class WindowResizeController extends Controller {
-  observe!: () => void
-  unobserve!: () => void
 
   constructor(context: Context) {
     super(context)
@@ -13,5 +11,8 @@ export class WindowResizeController extends Controller {
     })
   }
 
-  windowResize(payload: WindowResizePayload) { }
+  declare observe?: () => void
+  declare unobserve?: () => void
+  declare windowResize: (payload: WindowResizePayload) => void
+
 }


### PR DESCRIPTION
Hiya, 

Using a few of these in my Typescript projects. By describing the methods like they are currently
```
options!: *Functionality*Options
observe!: () => void
unobserve!: () => void
```
extending the controllers works fine, but it throws errors if a controller tries mixing in `use*Functionality*` without implementing all of them. 

Might just be my usage of them, but I found myself having to declare `observe` and `unobserve` on my controller even though I don't use them. And unless the user is extending the class - having a class property called `options` should be optional, given that mixin method allows passing inline options.

I've made changes so that the "extending" mode properties are not expected on the mixin function call signatures. 

---

Also fixed the type of `setTimeout` in the `use-debounce`, 

---

Let me know what you think.