### PR TITLE
Fix typo in ThrottleController, "trottles" instead of "throttles"

### DIFF
--- a/src/use-throttle/use-throttle.ts
+++ b/src/use-throttle/use-throttle.ts
@@ -6,7 +6,7 @@ export interface ThrottleOptions {
 }
 
 class ThrottleController extends Controller {
-  static trottles: string[] | ThrottleOptions[] = []
+  static throttles: string[] | ThrottleOptions[] = []
 }
 
 const defaultWait = 200


### PR DESCRIPTION
Hiya, 

Small typo fix I found when I was working on https://github.com/stimulus-use/stimulus-use/pull/105 