### PR TITLE
Fix use transition enter leave

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -21,7 +21,7 @@
   * [useThrottle](use-throttle.md)
 
 * [**Animation**](animation.md)
-  * [useTransition](transition.md)
+  * [useTransition](use-transition.md)
 
 * [**Application**](application.md)
   * [useApplication](application-controller.md)

--- a/docs/use-transition.md
+++ b/docs/use-transition.md
@@ -1,10 +1,91 @@
-# useTransition
+# useTransition (this is currently in beta version)
 
-Mixin or controller to apply classes to various stages of an element's transition.
+Mixin/controller to apply to apply transition effects when items are inserted, updated, or removed from the DOM (largely inspired by the Vue, AlpineJS & Tailwind world).
 
-**currently in beta subect to breaking changes**
+Transition is available both as a mixin to add transition behavior to your controller or as a standard controller to use with data attributes when you don't need additional customization.
 
+**Beta version subject to breaking changes. If you plan to use it register to the Github releases.**
 
-🚧 🚧 🚧 🚧 Documentation is in WIP during the beta
+## Mixin Reference
 
-examples are available in the [PR](https://github.com/stimulus-use/stimulus-use/pull/77)
+```javascript
+useTransition(controller, options = {})
+```
+
+**controller** : a Stimulus Controller (usually `'this'`)
+
+**options** :
+
+| Option| Description |Default value|
+|-----------------------|-------------|---------------------|
+| `element` | The element to transition| The controller element|
+|`enter`| Starting state for enter. Added before element is inserted, removed one frame after element is inserted. | |
+|`enterActive`| Active state for enter. Applied during the entire entering phase. Added before element is inserted, removed when transition/animation finishes. This class can be used to define the duration, delay and easing curve for the entering transition.||
+|`enterTo`| Ending state for enter. Added one frame after element is inserted (at the same time `enter` is removed), removed when transition/animation finishes.||
+|`leave`| Starting state for leave. Added immediately when a leaving transition is triggered, removed after one frame.||
+|`leaveActive`| Active state for leave. Applied during the entire leaving phase. Added immediately when leave transition is triggered, removed when the transition/animation finishes. This class can be used to define the duration, delay and easing curve for the leaving transition.||
+|`leaveTo`| Ending state for leave. Added one frame after a leaving transition is triggered (at the same time `leave` is removed), removed when the transition/animation finishes.||
+|`hiddenClass`| conditionnaly add a hidden class after `leave`, default is `hidden`, Set it to `false` to ignore it  |`hidden`|
+|`preserveOriginalClass`| Boolean value whether to preserve original class if some classes from the transition overlap with the initial classes of the the element.|`true`|
+|`removeToClasses`| Boolean value whether to remove the `To` classsed (`enterTo`, `leaveTo`) at the end of the transition|`true`|
+
+## Dirtectives
+
+Both Vue JS naming and Alpine are supported
+
+#### Vue JS directive style
+
+```html
+data-transition-enter="transform opacity-0 scale-95"
+data-transition-enter-active="transition ease-out duration-300"
+data-transition-enter-to="transform opacity-100 scale-100"
+data-transition-leave="transform opacity-100 scale-100"
+data-transition-leave-active="transition ease-in duration-300"
+data-transition-leave-to="transform opacity-0 scale-95"
+```
+
+#### Alpine JS directive style
+
+````html
+data-transition-enter-class="transform opacity-0 scale-95"
+data-transition-enter-start-class="transition ease-out duration-300"
+data-transition-enter-end-class="transform opacity-100 scale-100"
+data-transition-leave-class="transform opacity-100 scale-100"
+data-transition-leave-start-class="transition ease-in duration-300"
+data-transition-leave-end-class="transform opacity-0 scale-95"
+```
+
+**Example :**
+
+Here is a typical dropdown component from tailwind.
+
+```html
+<div class="relative"
+     data-controller="transition click-outside"
+     data-transition-target="content"
+     data-action="click-outside:click:ouside->">
+  <div>
+    <button
+      data-action="click->dropdown#toggle"
+      type="button"
+      class="inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+      Dropdown
+    </button>
+  </div>
+  <div class="origin-top-right absolute left-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5"
+  data-target="dropdown.content"
+  data-transition-enter="transform opacity-0 scale-95"
+  data-transition-enter-active="transition ease-out duration-300"
+  data-transition-enter-to="transform opacity-100 scale-100"
+  data-transition-leave="transform opacity-100 scale-100"
+  data-transition-leave-active="transition ease-in duration-300"
+  data-transition-leave-to="transform opacity-0 scale-95"
+  role="menu"
+  aria-orientation="vertical"
+  aria-labelledby="user-menu">
+    <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Your Profile</a>
+    <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Settings</a>
+    <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Sign out</a>
+  </div>
+</div>
+```

--- a/docs/use-transition.md
+++ b/docs/use-transition.md
@@ -1,6 +1,6 @@
 # useTransition (this is currently in beta version)
 
-Mixin/controller to apply to apply transition effects when items are inserted, updated, or removed from the DOM (largely inspired by the Vue, AlpineJS & Tailwind world).
+Mixin/controller to apply transition effects when items are inserted, updated, or removed from the DOM (largely inspired by the Vue, AlpineJS & Tailwind world).
 
 Transition is available both as a mixin to add transition behavior to your controller or as a standard controller to use with data attributes when you don't need additional customization.
 
@@ -25,11 +25,11 @@ useTransition(controller, options = {})
 |`leave`| Starting state for leave. Added immediately when a leaving transition is triggered, removed after one frame.||
 |`leaveActive`| Active state for leave. Applied during the entire leaving phase. Added immediately when leave transition is triggered, removed when the transition/animation finishes. This class can be used to define the duration, delay and easing curve for the leaving transition.||
 |`leaveTo`| Ending state for leave. Added one frame after a leaving transition is triggered (at the same time `leave` is removed), removed when the transition/animation finishes.||
-|`hiddenClass`| conditionnaly add a hidden class after `leave`, default is `hidden`, Set it to `false` to ignore it  |`hidden`|
-|`preserveOriginalClass`| Boolean value whether to preserve original class if some classes from the transition overlap with the initial classes of the the element.|`true`|
+|`hiddenClass`| Conditionally add a hidden class after `leave`, default is `hidden`, Set it to `false` to ignore it  |`hidden`|
+|`preserveOriginalClass`| Boolean value whether to preserve original class if some classes from the transition overlap with the initial classes of the element.|`true`|
 |`removeToClasses`| Boolean value whether to remove the `To` classsed (`enterTo`, `leaveTo`) at the end of the transition|`true`|
 
-## Dirtectives
+## Directives
 
 Both Vue JS naming and Alpine are supported
 
@@ -57,7 +57,7 @@ data-transition-leave-end-class="transform opacity-0 scale-95"
 
 **Example :**
 
-Here is a typical dropdown component from tailwind.
+Here is a typical dropdown component from Tailwind.
 
 ```html
 <div class="relative"

--- a/playground/controllers/dropdown_controller.js
+++ b/playground/controllers/dropdown_controller.js
@@ -7,11 +7,11 @@ export default class extends Controller {
   connect() {
     useClickOutside(this)
     const transitionOptions = {
-      enter: 'transition ease-out duration-300',
-      enterActive: 'transform opacity-0 scale-95',
+      enter: 'transform opacity-0 scale-95',
+      enterActive: 'transition ease-out duration-300',
       enterTo: 'transform opacity-100 scale-100',
-      leave: 'transition ease-in duration-300',
-      leaveActive: 'transform opacity-100 scale-100',
+      leave: 'transform opacity-100 scale-100',
+      leaveActive: 'transition ease-in duration-300',
       leaveTo: 'transform opacity-0 scale-95'
     }
     useTransition(this, transitionOptions)

--- a/playground/controllers/transition_controller.js
+++ b/playground/controllers/transition_controller.js
@@ -5,12 +5,13 @@ export default class extends Controller {
   connect() {
     useTransition(this, {
       enter: 'transform opacity-0 scale-50',
-      enterActive: 'transition ease-in duration-1000',
-      enterTo: 'transform opacity-100 scale-100',
+      enterActive: 'transition ease-in duration-300',
+      enterTo: 'transform opacity-100 scale-100 visible',
       leave: 'transform opacity-100 scale-100',
-      leaveActive: 'transition ease-out duration-1000',
+      leaveActive: 'transition ease-out duration-300',
       leaveTo: 'transform opacity-0 scale-50',
-      hiddenClass: true
+      removeToClasses: false,
+      hiddenClass: 'opacity-0'
     })
   }
 }

--- a/playground/controllers/transition_controller.js
+++ b/playground/controllers/transition_controller.js
@@ -4,13 +4,13 @@ import { useTransition } from 'stimulus-use'
 export default class extends Controller {
   connect() {
     useTransition(this, {
-      enter: 'transition ease-out duration-700',
-      enterActive: 'transform opacity-0 scale-0',
-      enterTo: 'transform opacity-1 scale-100',
-      leave: 'transition ease-in duration-100',
-      leaveActive: 'transform opacity-100 scale-100',
-      leaveTo: 'transform opacity-0 scale-0',
-      hiddenClass: false
+      enter: 'transform opacity-0 scale-50',
+      enterActive: 'transition ease-in duration-1000',
+      enterTo: 'transform opacity-100 scale-100',
+      leave: 'transform opacity-100 scale-100',
+      leaveActive: 'transition ease-out duration-1000',
+      leaveTo: 'transform opacity-0 scale-50',
+      hiddenClass: true
     })
   }
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -230,7 +230,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -243,7 +242,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -252,7 +250,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -261,38 +258,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -305,7 +270,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -314,7 +278,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -323,38 +286,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -367,7 +298,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -376,7 +306,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -385,7 +314,62 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -399,7 +383,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -408,7 +391,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -417,27 +399,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
-               class="opacity-0 flex items-center justify-center">
-            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </div>
-          <div></div>
-          <div data-controller="intersection transition"
-               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -448,7 +409,24 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
+               class="opacity-0 flex items-center justify-center">
+            <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div data-controller="intersection transition"
+               data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -462,7 +440,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -471,7 +448,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -480,7 +456,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -495,7 +470,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -504,7 +478,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -514,7 +487,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -527,7 +499,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -538,7 +509,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-700 delay-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -548,7 +518,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-1000"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
@@ -559,7 +528,6 @@
           <div></div>
           <div data-controller="intersection transition"
                data-action="intersection:appear->transition#enter intersection:disappear->transition#leave"
-               data-transition-enter="transition ease-out duration-500"
                class="opacity-0 flex items-center justify-center">
             <svg class="h20 w-20 text-blue-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />

--- a/spec/helpers/index.js
+++ b/spec/helpers/index.js
@@ -1,5 +1,5 @@
 export const nextFrame = async () => {
-  return await new Promise(resolve => requestAnimationFrame(resolve))
+  return new Promise(resolve => requestAnimationFrame(resolve))
 }
 
 export function delay(ms = 1) {
@@ -14,6 +14,14 @@ export const click = async selector => {
 export const remove = async selector => {
   document.querySelector(selector).remove()
   return nextFrame()
+}
+
+export const classList = selector => {
+  return document.querySelector(selector).classList.toString()
+}
+
+export const addAttribute = selector => {
+  return document.querySelector(selector).classList.toString()
 }
 
 export class TestLogger {

--- a/spec/use-intersection/use-intersection_spec.js
+++ b/spec/use-intersection/use-intersection_spec.js
@@ -119,17 +119,18 @@ scenarios.forEach(scenario => {
         })
       })
 
-      describe('scroll down', function () {
-        it('it fires one more "appear" for the second element and one disappear for the first', async function () {
-          await nextFrame()
-          await click('#scroll-down')
+      // lets move it to cypress
+      // describe('scroll down', function () {
+      //   it('it fires one more "appear" for the second element and one disappear for the first', async function () {
+      //     await nextFrame()
+      //     await click('#scroll-down')
 
-          expect(testLogger.eventsFilter({ id: ['1'], type: ['disappear'] }).length).to.equal(1)
-          expect(testLogger.eventsFilter({ id: ['2'], type: ['appear'] }).length).to.equal(1)
-          expect(testLogger.eventsFilter({ id: ['2'], type: ['disappear'] }).length).to.equal(0)
-          await click('#scroll-top')
-        })
-      })
+      //     expect(testLogger.eventsFilter({ id: ['1'], type: ['disappear'] }).length).to.equal(1)
+      //     expect(testLogger.eventsFilter({ id: ['2'], type: ['appear'] }).length).to.equal(1)
+      //     expect(testLogger.eventsFilter({ id: ['2'], type: ['disappear'] }).length).to.equal(0)
+      //     await click('#scroll-top')
+      //   })
+      // })
     })
   })
 })

--- a/spec/use-intersection/use-intersection_spec.js
+++ b/spec/use-intersection/use-intersection_spec.js
@@ -119,18 +119,17 @@ scenarios.forEach(scenario => {
         })
       })
 
-      // lets move it to e2e tests
-      // describe('scroll down', function () {
-      //   it('it fires one more "appear" for the second element and one disappear for the first', async function () {
-      //     await nextFrame()
-      //     await click('#scroll-down')
+      describe('scroll down', function () {
+        it('it fires one more "appear" for the second element and one disappear for the first', async function () {
+          await nextFrame()
+          await click('#scroll-down')
 
-      //     expect(testLogger.eventsFilter({ id: ['1'], type: ['disappear'] }).length).to.equal(1)
-      //     expect(testLogger.eventsFilter({ id: ['2'], type: ['appear'] }).length).to.equal(1)
-      //     expect(testLogger.eventsFilter({ id: ['2'], type: ['disappear'] }).length).to.equal(0)
-      //     await click('#scroll-top')
-      //   })
-      // })
+          expect(testLogger.eventsFilter({ id: ['1'], type: ['disappear'] }).length).to.equal(1)
+          expect(testLogger.eventsFilter({ id: ['2'], type: ['appear'] }).length).to.equal(1)
+          expect(testLogger.eventsFilter({ id: ['2'], type: ['disappear'] }).length).to.equal(0)
+          await click('#scroll-top')
+        })
+      })
     })
   })
 })

--- a/spec/use-transition/fixtures.js
+++ b/spec/use-transition/fixtures.js
@@ -1,11 +1,13 @@
 export const fixtureBase = `
-  <div data-controller="transition" data-action="click->transition#toggle" id="transitionable-element"
-        data-transition-enter="transition ease-out duration-300"
-        data-transition-enter-active="transform opacity-0 scale-95"
-        data-transition-enter-to="transform opacity-100 scale-100"
-        data-transition-leave="transition ease-in duration-300"
-        data-transition-leave-active="transform opacity-100 scale-100"
-        data-transition-leave-to="transform opacity-0 scale-95" >
+  <div data-controller="transition" data-action="click->transition#toggleTransition" id="transitionable-element"
+        data-transition-enter="enter-class"
+        data-transition-enter-active="enter-active-class"
+        data-transition-enter-to="enter-to-class"
+        data-transition-leave="leave-class"
+        data-transition-leave-active="leave-active-class"
+        data-transition-leave-to="leave-to-class"
+        class="hidden"
+        style="transition-duration: 30ms" >
     <div>Content</div>
   </div>
 `

--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -137,7 +137,7 @@ export const useTransition = (controller: TransitionComposableController, option
     // remove the initial class on frame after the beginning of the transition
     removeClasses(element, initialClasses)
 
-    // add the endDlass on frame after the beginning of the transition
+    // add the endClass on frame after the beginning of the transition
     addClasses(element, endClasses);
 
     // dynamically comput the duration of the transition from the style of the element

--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -10,6 +10,9 @@ export interface TransitionOptions {
   leaveActive?: string
   leaveTo?: string
   hiddenClass?: string
+  leaveAfter?: number
+  preserveOriginalClass?: boolean
+  removeToClasses?: boolean
 }
 
 const alpineNames: object = {
@@ -23,7 +26,9 @@ const alpineNames: object = {
 
 const defaultOptions = {
   transitioned: false,
-  hiddenClass: "hidden"
+  hiddenClass: "hidden",
+  preserveOriginalClass: true,
+  removeToClasses: true
 }
 
 export const useTransition = (controller: TransitionComposableController, options: TransitionOptions = {}) => {
@@ -40,7 +45,9 @@ export const useTransition = (controller: TransitionComposableController, option
   if (!((targetElement instanceof HTMLElement) || (targetElement instanceof SVGElement))) return
   const dataset = targetElement.dataset
 
-  const { transitioned, hiddenClass } = Object.assign(defaultOptions, options)
+  const leaveAfter = parseInt(dataset.leaveAfter || "") || options.leaveAfter || 0
+
+  const { transitioned, hiddenClass, preserveOriginalClass, removeToClasses } = Object.assign(defaultOptions, options)
 
   const controllerEnter = controller.enter?.bind(controller)
   const controllerLeave = controller.leave?.bind(controller)
@@ -52,16 +59,26 @@ export const useTransition = (controller: TransitionComposableController, option
     controller.transitioned = true
     controllerEnter && controllerEnter(event)
 
-    const enterClass = getAttribute("enter", options, dataset)
-    const enterActiveClass = getAttribute("enterActive", options, dataset)
-    const enterToClass = getAttribute("enterTo", options, dataset)
+    const enterClasses = getAttribute("enter", options, dataset)
+    const enterActiveClasses = getAttribute("enterActive", options, dataset)
+    const enterToClasses = getAttribute("enterTo", options, dataset)
+    const leaveToClasses = getAttribute("leaveTo", options, dataset)
 
     if (!!hiddenClass) {
       targetElement.classList.remove(hiddenClass)
     }
 
-    await transition(targetElement, enterClass, enterActiveClass, enterToClass)
+    if (!removeToClasses) {
+      removeClasses(targetElement, leaveToClasses)
+    }
+    await transition(targetElement, enterClasses, enterActiveClasses, enterToClasses, hiddenClass, preserveOriginalClass, removeToClasses)
 
+    if (leaveAfter > 0) {
+      setTimeout(() => {
+        leave(event)
+        console.log("after");
+      }, leaveAfter)
+    }
   }
 
   async function leave(event?: Event) {
@@ -69,11 +86,16 @@ export const useTransition = (controller: TransitionComposableController, option
     controller.transitioned = false
     controllerLeave && controllerLeave(event)
 
-    const leaveClass = getAttribute("leave", options, dataset)
-    const leaveActiveClass = getAttribute("leaveActive", options, dataset)
-    const leaveToClass = getAttribute("leaveTo", options, dataset)
+    const leaveClasses = getAttribute("leave", options, dataset)
+    const leaveActiveClasses = getAttribute("leaveActive", options, dataset)
+    const leaveToClasses = getAttribute("leaveTo", options, dataset)
+    const enterToClasses = getAttribute("enterTo", options, dataset)
 
-    await transition(targetElement, leaveClass, leaveActiveClass, leaveToClass)
+    if (!removeToClasses) {
+      removeClasses(targetElement, enterToClasses)
+    }
+
+    await transition(targetElement, leaveClasses, leaveActiveClasses, leaveToClasses, hiddenClass, preserveOriginalClass, removeToClasses)
 
     if (!!hiddenClass) {
       targetElement.classList.add(hiddenClass)
@@ -90,17 +112,45 @@ export const useTransition = (controller: TransitionComposableController, option
     }
   }
 
-  async function transition(element: Element, initialClass: string[], activeClass: string[], toClass: string[]) {
-    element.classList.add(...initialClass);
-    element.classList.add(...activeClass);
-    await nextFrame();
+  async function transition(element: Element, initialClasses: string[], activeClasses: string[], endClasses: string[], hiddenClass: string, preserveOriginalClass: boolean, removeEndClasses: boolean) {
 
-    element.classList.remove(...activeClass);
-    element.classList.add(...toClass);
+    // if there's any overlap between the current set of classes and initialClasses/activeClasses/endClasses,
+    // we should remove them before we start and add them back at the end
+    const stashedClasses: string[] = []
+    if (preserveOriginalClass) {
+      initialClasses.forEach(cls => element.classList.contains(cls) && cls !== hiddenClass && stashedClasses.push(cls))
+      activeClasses.forEach(cls => element.classList.contains(cls) && cls !== hiddenClass && stashedClasses.push(cls))
+      endClasses.forEach(cls => element.classList.contains(cls) && cls !== hiddenClass && stashedClasses.push(cls))
+    }
 
+
+    // Add initial class before element start transition
+    addClasses(element, initialClasses);
+
+    // remove the overlapping classes
+    removeClasses(element, stashedClasses)
+
+    // Add active class before element start transition and maitain it during the entire transition.
+    addClasses(element, activeClasses)
+    await nextAnimationFrame();
+
+    // remove the initial class on frame after the beginning of the transition
+    removeClasses(element, initialClasses)
+
+    // add the endDlass on frame after the beginning of the transition
+    addClasses(element, endClasses);
+
+    // dynamically comput the duration of the transition from the style of the element
     await afterTransition(element);
 
-    element.classList.remove(...initialClass);
+    // remove both activeClasses and endClasses
+    removeClasses(element, activeClasses)
+    if (removeEndClasses) {
+      removeClasses(element, endClasses)
+    }
+
+    // restore the overlaping classes
+    addClasses(element, stashedClasses)
   }
 
   function initialState() {
@@ -118,16 +168,28 @@ export const useTransition = (controller: TransitionComposableController, option
     }
   }
 
+  function addClasses(element: Element, classes: string[]) {
+    if (classes.length > 0) {
+      element.classList.add(...classes);
+    }
+  }
+
+  function removeClasses(element: Element, classes: string[]) {
+    if (classes.length > 0) {
+      element.classList.remove(...classes);
+    }
+  }
+
   initialState()
   Object.assign(controller, { enter, leave, toggleTransition })
   return [enter, leave, toggleTransition]
 }
 
-function getAttribute(name: string, options: TransitionOptions, dataset: DOMStringMap) {
+function getAttribute(name: string, options: TransitionOptions, dataset: DOMStringMap): string[] {
   const datasetName = `transition${name[0].toUpperCase()}${name.substr(1)}`
   const datasetAlpineName = (alpineNames as any)[name]
-  const classes = (options as any)[name] || dataset[datasetName] || dataset[datasetAlpineName] || ""
-  return classes.split(" ")
+  const classes = (options as any)[name] || dataset[datasetName] || dataset[datasetAlpineName] || " "
+  return isEmpty(classes) ? [] : classes.split(" ")
 }
 
 async function afterTransition(element: Element): Promise<number> {
@@ -138,17 +200,20 @@ async function afterTransition(element: Element): Promise<number> {
         .split(",")[0]
         .replace('s', '')
     ) * 1000
-
     setTimeout(() => {
       resolve(duration)
     }, duration)
   });
 }
 
-async function nextFrame() {
+async function nextAnimationFrame() {
   return new Promise(resolve => {
     requestAnimationFrame(() => {
       requestAnimationFrame(resolve);
     });
   });
+}
+
+function isEmpty(str: string): boolean {
+  return (str.length === 0 || !str.trim());
 }


### PR DESCRIPTION
- Close #110 by introducing a new option `removeToClasses` (default to true) that will remove the `To` classes once the transition is finished

- adds support for preserving initial classes as reported by @jduff in #77

- Relates #108 only a basic documentation for now. 

I think this should fix quite a few strange behavior I have seen with the mixin. 

The next step is to make all options available as directives

