### PR TITLE
rename enter/leave classe from Vue2 syntax to Vue3

### DIFF
--- a/docs/use-transition.md
+++ b/docs/use-transition.md
@@ -19,14 +19,14 @@ useTransition(controller, options = {})
 | Option| Description |Default value|
 |-----------------------|-------------|---------------------|
 | `element` | The element to transition| The controller element|
-|`enter`| Starting state for enter. Added before element is inserted, removed one frame after element is inserted. | |
 |`enterActive`| Active state for enter. Applied during the entire entering phase. Added before element is inserted, removed when transition/animation finishes. This class can be used to define the duration, delay and easing curve for the entering transition.||
-|`enterTo`| Ending state for enter. Added one frame after element is inserted (at the same time `enter` is removed), removed when transition/animation finishes.||
-|`leave`| Starting state for leave. Added immediately when a leaving transition is triggered, removed after one frame.||
+|`enterFrom`| Starting state for enter. Added before element is inserted, removed one frame after element is inserted. | |
+|`enterTo`| Ending state for enter. Added one frame after element is inserted (at the same time `enterFrom` is removed), removed when transition/animation finishes.||
 |`leaveActive`| Active state for leave. Applied during the entire leaving phase. Added immediately when leave transition is triggered, removed when the transition/animation finishes. This class can be used to define the duration, delay and easing curve for the leaving transition.||
-|`leaveTo`| Ending state for leave. Added one frame after a leaving transition is triggered (at the same time `leave` is removed), removed when the transition/animation finishes.||
+|`leaveFrom`| Starting state for leave. Added immediately when a leaving transition is triggered, removed after one frame.||
+|`leaveTo`| Ending state for leave. Added one frame after a leaving transition is triggered (at the same time `leaveFrom` is removed), removed when the transition/animation finishes.||
 |`hiddenClass`| Conditionally add a hidden class after `leave`, default is `hidden`, Set it to `false` to ignore it  |`hidden`|
-|`preserveOriginalClass`| Boolean value whether to preserve original class if some classes from the transition overlap with the initial classes of the element.|`true`|
+|`preserveOriginalClass`| Boolean value whether to preserve original class, if some classes from the transition overlap with the initial classes of the element.|`true`|
 |`removeToClasses`| Boolean value whether to remove the `To` classsed (`enterTo`, `leaveTo`) at the end of the transition|`true`|
 
 ## Directives
@@ -36,11 +36,11 @@ Both Vue JS naming and Alpine are supported
 #### Vue JS directive style
 
 ```html
-data-transition-enter="transform opacity-0 scale-95"
 data-transition-enter-active="transition ease-out duration-300"
+data-transition-enter-from="transform opacity-0 scale-95"
 data-transition-enter-to="transform opacity-100 scale-100"
-data-transition-leave="transform opacity-100 scale-100"
 data-transition-leave-active="transition ease-in duration-300"
+data-transition-leave-from="transform opacity-100 scale-100"
 data-transition-leave-to="transform opacity-0 scale-95"
 ```
 
@@ -74,11 +74,11 @@ Here is a typical dropdown component from Tailwind.
   </div>
   <div class="origin-top-right absolute left-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5"
   data-target="dropdown.content"
-  data-transition-enter="transform opacity-0 scale-95"
   data-transition-enter-active="transition ease-out duration-300"
+  data-transition-enter-from="transform opacity-0 scale-95"
   data-transition-enter-to="transform opacity-100 scale-100"
-  data-transition-leave="transform opacity-100 scale-100"
   data-transition-leave-active="transition ease-in duration-300"
+  data-transition-leave-from="transform opacity-100 scale-100"
   data-transition-leave-to="transform opacity-0 scale-95"
   role="menu"
   aria-orientation="vertical"

--- a/playground/controllers/dropdown_controller.js
+++ b/playground/controllers/dropdown_controller.js
@@ -7,11 +7,11 @@ export default class extends Controller {
   connect() {
     useClickOutside(this)
     const transitionOptions = {
-      enter: 'transform opacity-0 scale-95',
       enterActive: 'transition ease-out duration-300',
+      enterFrom: 'transform opacity-0 scale-95',
       enterTo: 'transform opacity-100 scale-100',
-      leave: 'transform opacity-100 scale-100',
       leaveActive: 'transition ease-in duration-300',
+      leaveFrom: 'transform opacity-100 scale-100',
       leaveTo: 'transform opacity-0 scale-95'
     }
     useTransition(this, transitionOptions)

--- a/playground/controllers/transition_controller.js
+++ b/playground/controllers/transition_controller.js
@@ -4,11 +4,11 @@ import { useTransition } from 'stimulus-use'
 export default class extends Controller {
   connect() {
     useTransition(this, {
-      enter: 'transform opacity-0 scale-50',
       enterActive: 'transition ease-in duration-300',
+      enterFrom: 'transform opacity-0 scale-50',
       enterTo: 'transform opacity-100 scale-100 visible',
-      leave: 'transform opacity-100 scale-100',
       leaveActive: 'transition ease-out duration-300',
+      leaveFrom: 'transform opacity-100 scale-100',
       leaveTo: 'transform opacity-0 scale-50',
       removeToClasses: false,
       hiddenClass: 'opacity-0'

--- a/spec/use-transition/fixtures.js
+++ b/spec/use-transition/fixtures.js
@@ -1,10 +1,10 @@
 export const fixtureBase = `
   <div data-controller="transition" data-action="click->transition#toggleTransition" id="transitionable-element"
-        data-transition-enter="enter-class"
         data-transition-enter-active="enter-active-class"
+        data-transition-enter-from="enter-from-class"
         data-transition-enter-to="enter-to-class"
-        data-transition-leave="leave-class"
         data-transition-leave-active="leave-active-class"
+        data-transition-leave-from="leave-from-class"
         data-transition-leave-to="leave-to-class"
         class="hidden"
         style="transition-duration: 30ms" >

--- a/spec/use-transition/use-transition_spec.js
+++ b/spec/use-transition/use-transition_spec.js
@@ -50,7 +50,7 @@ controllers.forEach(Controller => {
         // enter
         expect(classList('#transitionable-element')).to.equal('hidden')
         await click('#transitionable-element')
-        expect(classList('#transitionable-element')).to.equal('enter-class enter-active-class')
+        expect(classList('#transitionable-element')).to.equal('enter-from-class enter-active-class')
 
         await nextFrame()
         expect(classList('#transitionable-element')).to.equal('enter-active-class enter-to-class')
@@ -60,7 +60,7 @@ controllers.forEach(Controller => {
 
         // leave
         await click('#transitionable-element')
-        expect(classList('#transitionable-element')).to.equal('leave-class leave-active-class')
+        expect(classList('#transitionable-element')).to.equal('leave-from-class leave-active-class')
 
         await nextFrame()
         expect(classList('#transitionable-element')).to.equal('leave-active-class leave-to-class')
@@ -78,7 +78,7 @@ controllers.forEach(Controller => {
         // enter
         await click('#transitionable-element')
         expect(sortClasses(classList('#transitionable-element'))).to.equal(
-          sortClasses('to-preserve enter-class enter-active-class')
+          sortClasses('to-preserve enter-from-class enter-active-class')
         )
 
         await nextFrame()

--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -3,11 +3,11 @@ import { TransitionComposableController } from './transition-controller'
 export interface TransitionOptions {
   element?: Element
   transitioned?: boolean
-  enter?: string
   enterActive?: string
+  enterFrom?: string
   enterTo?: string
-  leave?: string
   leaveActive?: string
+  leaveFrom?: string
   leaveTo?: string
   hiddenClass?: string
   leaveAfter?: number
@@ -16,10 +16,10 @@ export interface TransitionOptions {
 }
 
 const alpineNames: object = {
-  enterClass: "enter",
+  enterFromClass: "enter",
   enterActiveClass: "enterStart",
   enterToClass: "enterEnd",
-  leaveClass: "leave",
+  leaveFromClass: "leave",
   leaveActiveClass: "leaveStart",
   leaveToClass: "leaveEnd",
 }
@@ -59,7 +59,7 @@ export const useTransition = (controller: TransitionComposableController, option
     controller.transitioned = true
     controllerEnter && controllerEnter(event)
 
-    const enterClasses = getAttribute("enter", options, dataset)
+    const enterFromClasses = getAttribute("enterFrom", options, dataset)
     const enterActiveClasses = getAttribute("enterActive", options, dataset)
     const enterToClasses = getAttribute("enterTo", options, dataset)
     const leaveToClasses = getAttribute("leaveTo", options, dataset)
@@ -71,12 +71,11 @@ export const useTransition = (controller: TransitionComposableController, option
     if (!removeToClasses) {
       removeClasses(targetElement, leaveToClasses)
     }
-    await transition(targetElement, enterClasses, enterActiveClasses, enterToClasses, hiddenClass, preserveOriginalClass, removeToClasses)
+    await transition(targetElement, enterFromClasses, enterActiveClasses, enterToClasses, hiddenClass, preserveOriginalClass, removeToClasses)
 
     if (leaveAfter > 0) {
       setTimeout(() => {
         leave(event)
-        console.log("after");
       }, leaveAfter)
     }
   }
@@ -86,7 +85,7 @@ export const useTransition = (controller: TransitionComposableController, option
     controller.transitioned = false
     controllerLeave && controllerLeave(event)
 
-    const leaveClasses = getAttribute("leave", options, dataset)
+    const leaveFromClasses = getAttribute("leaveFrom", options, dataset)
     const leaveActiveClasses = getAttribute("leaveActive", options, dataset)
     const leaveToClasses = getAttribute("leaveTo", options, dataset)
     const enterToClasses = getAttribute("enterTo", options, dataset)
@@ -95,7 +94,7 @@ export const useTransition = (controller: TransitionComposableController, option
       removeClasses(targetElement, enterToClasses)
     }
 
-    await transition(targetElement, leaveClasses, leaveActiveClasses, leaveToClasses, hiddenClass, preserveOriginalClass, removeToClasses)
+    await transition(targetElement, leaveFromClasses, leaveActiveClasses, leaveToClasses, hiddenClass, preserveOriginalClass, removeToClasses)
 
     if (!!hiddenClass) {
       targetElement.classList.add(hiddenClass)


### PR DESCRIPTION
close #116

## Breaking change

use the new Vue3 syntax adding `from` suffix

`enter` become `enterFrom`
`leave` becomes `leavFrom`
