### PR TITLE
log correct event name in `dispatch()` when using `eventPrefix`

### DIFF
--- a/src/stimulus-use.ts
+++ b/src/stimulus-use.ts
@@ -61,7 +61,7 @@ export class StimulusUse {
       const { event, ...eventDetails } = details
       const customEvent = this.extendedEvent(eventName, event || null, eventDetails)
       this.targetElement.dispatchEvent(customEvent)
-      this.log('dispatchEvent', { eventName, ...eventDetails })
+      this.log('dispatchEvent', { eventName: customEvent.type, ...eventDetails })
     }
   }
 


### PR DESCRIPTION
I noticed that when using a custom `eventPrefix` that the `dispatch()` function logs the wrong `eventName`. 

If you check the log messages in the dev tools and expand the details you will see the the the `eventName` is logged without the prefix while the right eventName (with the prefix) is actually emitted. 

This PR fixes the log output to match the actual dispatched event. 