### PR TITLE
ApplicationController isPreview - Add support for Hotwire/Turbo

### DIFF
--- a/spec/use-application_spec.js
+++ b/spec/use-application_spec.js
@@ -74,6 +74,9 @@ controllers.forEach(Controller => {
         document.documentElement.setAttribute('data-turbolinks-preview', true)
         expect(application.controllers[0].isPreview).to.equal(true)
         document.documentElement.removeAttribute('data-turbolinks-preview')
+        document.documentElement.setAttribute('data-turbo-preview', true)
+        expect(application.controllers[0].isPreview).to.equal(true)
+        document.documentElement.removeAttribute('data-turbo-preview')
       })
 
       it('csrf token is correctly updated', async function () {

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -2,10 +2,10 @@ import { Controller } from 'stimulus'
 import { useDispatch, DispatchOptions } from '../use-dispatch/index'
 
 export const useApplication = (controller: Controller, options: DispatchOptions= {}) => {
-  // getter to detect Turbolink preview
+  // getter to detect Turbolinks preview
   Object.defineProperty(controller, 'isPreview', {
     get(): boolean {
-      return document.documentElement.hasAttribute('data-turbolinks-preview')
+      return document.documentElement.hasAttribute('data-turbolinks-preview') || document.documentElement.hasAttribute('data-turbo-preview')
     },
   })
 


### PR DESCRIPTION
Hiya,

Just spotted that this hasn't been updated to support Hotwire/Turbo (https://turbo.hotwire.dev/handbook/building#detecting-when-a-preview-is-visible) 

Thought I'd pop out a quick PR if you want it.