### PR TITLE
Add `isConnected` helper to `ApplicationController`

### DIFF
--- a/docs/application-controller.md
+++ b/docs/application-controller.md
@@ -27,6 +27,7 @@ export default class extends ApplicationController {
 
   connect() {
     this.isPreview // true/false if it is a Turbolinks preview
+    this.isConnected // true/false if the controller is connected
     this.dispatch("hello") // helper to dispatch a custom event "greet:hello" to other Stimulus controllers
   }
 }
@@ -40,7 +41,9 @@ export default class extends ApplicationController {
 
 **Getters**
 
-**`isPreview`**: return true/false whether the current page is a Turbolinks preview. [Use case for playing animations with Turbolinks](https://dev.to/adrienpoly/animations-with-turbolinks-and-stimulus-4862)
+**`isPreview`**: returns `true`/`false` whether the current page is a Turbolinks preview. [Use case for playing animations with Turbolinks](https://dev.to/adrienpoly/animations-with-turbolinks-and-stimulus-4862)
+
+**`isConnected`**: returns `true`/`false` for whether the Stimulus controller is connected or not.
 
 **`csrfToken`**: return the csrf token if any
 

--- a/src/use-application/application-controller.ts
+++ b/src/use-application/application-controller.ts
@@ -5,6 +5,7 @@ import { DispatchOptions } from "../use-dispatch"
 export class ApplicationController extends Controller {
   options?: DispatchOptions
   readonly isPreview: boolean = false
+  readonly isConnected: boolean = false
   readonly csrfToken: string = ''
 
 

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -9,7 +9,7 @@ export const useApplication = (controller: Controller, options: DispatchOptions=
     },
   })
 
-  // getter to detect if a Stimulus controller is mounted
+  // getter to detect if a Stimulus controller is connected
   Object.defineProperty(controller, 'isConnected', {
     get(): boolean {
       return !!Array.from(this.context.module.connectedContexts).find(c => c === this.context)

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -9,6 +9,13 @@ export const useApplication = (controller: Controller, options: DispatchOptions=
     },
   })
 
+  // getter to detect if a Stimulus controller is mounted
+  Object.defineProperty(controller, 'isConnected', {
+    get(): boolean {
+      return !!Array.from(this.context.module.connectedContexts).find(c => c === this.context)
+    },
+  })
+
   // getter to get the csrf token
   Object.defineProperty(controller, 'csrfToken', {
     get(): boolean {


### PR DESCRIPTION
### `isConnected` helper

This PR adds a `isConnected` helper function the the `ApplicationController`.

This helper function can be used to detect whether a Stimulus controller is connected or not.

#### Example

```js
import { ApplicationController } from 'stimulus-use'

export default class extends ApplicationController {
  initialize() {
    console.log("initialize", this.isConnected) // => false
  }

  connect() {
    console.log("connect", this.isConnected) // => true
  }

  anyOtherAction() {
    console.log("anyOtherAction", this.isConnected) // => true
  }

  disconnect() {
    console.log("disconnect", this.isConnected) // => false
  }
}
```