### PR TITLE
clean: remove redundant targetElement property

### DIFF
--- a/src/use-dispatch/use-dispatch.ts
+++ b/src/use-dispatch/use-dispatch.ts
@@ -16,7 +16,6 @@ const defaultOptions = {
 }
 
 export class UseDispatch extends StimulusUse {
-  targetElement: Element
   eventPrefix: boolean | string
   bubbles: boolean
   cancelable: boolean

--- a/src/use-mutation/use-mutation.ts
+++ b/src/use-mutation/use-mutation.ts
@@ -10,7 +10,6 @@ export interface MutationOptions extends MutationObserverInit, MutationControlle
 export class UseMutation extends StimulusUse {
   controller: MutationComposableController
   observer: MutationObserver
-  targetElement: Element
   options: MutationOptions
 
   constructor(controller: MutationComposableController, options: MutationOptions = {}) {


### PR DESCRIPTION
The StimulusUse base class already provides this property.