### PR TITLE
Fix isElementInViewport

### DIFF
--- a/src/support/index.ts
+++ b/src/support/index.ts
@@ -41,8 +41,8 @@ export function isElementInViewport(el: Element) {
   const windowHeight = window.innerHeight || document.documentElement.clientHeight
   const windowWidth = window.innerWidth || document.documentElement.clientWidth
 
-  const vertInView = rect.top <= windowHeight && rect.top + rect.height >= 0
-  const horInView = rect.left <= windowWidth && rect.left + rect.width >= 0
+  const vertInView = rect.top <= windowHeight && rect.top + rect.height > 0
+  const horInView = rect.left <= windowWidth && rect.left + rect.width > 0
 
   return vertInView && horInView
 }


### PR DESCRIPTION
Hi!

The function [`isElementInViewport`] don't work as expected because is detecting the element in the viewport when it is not.

When an element is hidden (display: none) this is its size and position (checked on FF and Chrome): 
```js
DOMRect { x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0 }
```

While when using a tailwind class like `-translate-x-full` (checked on FF):
```js
DOMRect { x: -448, y: 0, width: 448, height: 419, top: 0, right: 0, bottom: 419, left: -448 }
```

The function should not return true when the result of `rect.top + rect.height` or `rect.left + rect.width` is zero.

Thanks!