### PR TITLE
clears timeout on unobserve

### DIFF
--- a/src/use-idle/use-idle.ts
+++ b/src/use-idle/use-idle.ts
@@ -84,6 +84,7 @@ export const useIdle = (controller: IdleComposableController, options: IdleOptio
   }
 
   const unobserve = () => {
+    clearTimeout(timeout)
     events.forEach(event => {
       window.removeEventListener(event, onEvent)
     })


### PR DESCRIPTION
I wanted to use useIdle in my project, in which I work with rails, turbo and stimulus. When I navigate with Turbo between two pages, both with a useIdle instance, the away event is dispatched multiple times, because the timer is not stopped on disconnect / unobserve.