### PR TITLE
Update useDebounce to provide default (empty) DebouceOptions matching documentation and improving DX

### DIFF
--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -6,7 +6,7 @@ export interface DebounceOptions {
 }
 
 class DebounceController extends Controller {
-  static debounces: string[] | DebounceOptions[] = []
+  static debounces: (string | DebounceOptions)[] = []  
 }
 
 const defaultWait = 200
@@ -26,10 +26,10 @@ const debounce = (fn: Function, wait: number = defaultWait) => {
   }
 }
 
-export const useDebounce = (controller: DebounceController, options: DebounceOptions) => {
-  const constructor = controller.constructor as any
+export const useDebounce = (controller: DebounceController, options: DebounceOptions = {}) => {
+  const constructor = controller.constructor as typeof DebounceController
 
-  constructor.debounces?.forEach((func: string | DebounceOptions) => {
+  constructor.debounces.forEach((func: string | DebounceOptions) => {
     if (typeof func === 'string') {
       ;(controller as any)[func] = debounce((controller as any)[func] as Function, options?.wait)
     }

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -26,7 +26,7 @@ const debounce = (fn: Function, wait: number = defaultWait) => {
   }
 }
 
-export const useDebounce = (controller: DebounceController, options: DebounceOptions = {}) => {
+export const useDebounce = (controller: DebounceController, options?: DebounceOptions) => {
   const constructor = controller.constructor as typeof DebounceController
 
   constructor.debounces.forEach((func: string | DebounceOptions) => {

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -6,7 +6,7 @@ export interface DebounceOptions {
 }
 
 class DebounceController extends Controller {
-  static debounces: (string | DebounceOptions)[] = []  
+  static debounces: (string | DebounceOptions)[] = []
 }
 
 const defaultWait = 200


### PR DESCRIPTION
- make DebounceOptions optional for useDebounce to match docs
- fix typing to match parsing logic, should be array (string | opts) vs (array of string) | (array of opts)
- type constructor more precisely in useDebounce which removes need for optional chaining