### PR TITLE
Fix `useIntersection` for multiple elements in the same controller

### DIFF
--- a/docs/use-intersection.md
+++ b/docs/use-intersection.md
@@ -31,7 +31,7 @@ import { useIntersection } from 'stimulus-use'
 
 export default class extends Controller {
   connect() {
-    useIntersection(this, { element: this.element })
+    useIntersection(this)
   }
 
   appear(entry) {

--- a/docs/use-intersection.md
+++ b/docs/use-intersection.md
@@ -81,6 +81,9 @@ export default class extends Controller {
   connect() {
     useIntersection(this, { eventPrefix: false })
   }
+
+  increase() { /* ... */ }
+  decrease() { /* ... */ }
 }
 ```
 
@@ -104,7 +107,7 @@ Since the `data-controller` and the `data-action` are on the same element you ca
 </div>
 ```
 
-### Event Details
+### Event Details
 
 Get the emitting controller and entry object for an appear event
 

--- a/docs/use-intersection.md
+++ b/docs/use-intersection.md
@@ -122,16 +122,42 @@ count(event) {
 If you are tracking multiple events in your controller you might find these helper functions handy:
 
 | Helper | Description |
-| -------- | ----------- |
+| --- | --- |
 | `this.isVisible()` / `this.allVisible()` | Returns `true` if **all** of the tracked elements are visible. |
 | `this.noneVisible()` | Returns `true` if **none** of the tracked elements are visible. |
 | `this.oneVisible()` | Returns `true` if **exactly one** of the tracked elements is visible. |
 | `this.atLeastOneVisible()` | Returns `true` if **at least one** of the tracked elements is visible. |
 
+### Using Helper functions
+
+```js
+import { Controller } from '@hotwired/stimulus'
+import { useIntersection } from 'stimulus-use'
+
+export default class extends Controller {
+  static targets = [ 'menu' ]
+
+  connect() {
+    useIntersection(this)
+  }
+
+  appear() {
+    if (this.atLeastOneVisible()) {
+      this.menuTarget.show()
+    }
+  }
+
+  disappear() {
+    if (this.noneVisible()) {
+      this.menuTarget.hide()
+    }
+  }
+}
+```
 
 ## Example
 
-Rails Infinite scroll : https://github.com/adrienpoly/infinite-scroll-stimulus-js
+Rails Infinite scroll: https://github.com/adrienpoly/infinite-scroll-stimulus-js
 
 
 ## Polyfill

--- a/docs/use-intersection.md
+++ b/docs/use-intersection.md
@@ -16,12 +16,10 @@ useIntersection(controller, options = {})
 
 | Option| Description |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default&nbsp;value&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|
 |-----------------------|-------------|---------------------|
-| `dispatchEvent` | Whether to dispatch `appear`, `disappear` events or not.| `true` |
-| `element` | The root element listening to intersection events.| The controller element|
+| `dispatchEvent` | Whether to dispatch `appear`, `disappear` events or not. | `true` |
+| `element` | The root element listening to intersection events. | The controller element|
 |`eventPrefix`| Whether to prefix or not the emitted event. Can be a **boolean** or a **string**.<br>- **true** prefix the event with the controller identifier `card:appear` <br>- **someString** prefix the event with the given string `someString:appear` <br>- **false** to remove prefix  |true|
-| `root` | The element that is used as the viewport for checking visibility of the target. Must be the ancestor of the target. | Defaults to the browser viewport if not specified or if null. |
-| `rootMargin` | Margin around the root. Can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left). The values can be percentages. This set of values serves to grow or shrink each side of the root element's bounding box before computing intersections. | "0px 0px 0px 0px" |
-| `threshold` | Either a single number or an array of numbers which indicate at what percentage of the target's visibility the observer's callback should be executed. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. If you want the callback to run every time visibility passes another 25%, you would specify the array [0, 0.25, 0.5, 0.75, 1]. The default is 0 (meaning as soon as even one pixel is visible, the callback will be run). A value of 1.0 means that the threshold isn't considered passed until every pixel is visible. | 0 |
+| `visibleAttribute` | The name of the attribute which gets added to the tracked element when the element is visible | `isVisible` |
 
 ## Usage
 
@@ -32,12 +30,8 @@ import { Controller } from '@hotwired/stimulus'
 import { useIntersection } from 'stimulus-use'
 
 export default class extends Controller {
-  options = {
-    threshold: 0, // default
-  }
-
   connect() {
-    useIntersection(this, this.options)
+    useIntersection(this, { element: this.element })
   }
 
   appear(entry) {
@@ -59,7 +53,7 @@ import { IntersectionController } from 'stimulus-use'
 
 export default class extends IntersectionController {
   options = {
-    threshold: 0, // default
+    element: this.element, // default
   }
 
   appear(entry) {
@@ -73,17 +67,44 @@ export default class extends IntersectionController {
 ```
 
 
-
 ## Events
 
-This module adds two new events `appear` and `disapear` event that you may use to triggers stimulus actions
+This module adds two new events `appear` and `disapear` event that you may use to triggers Stimulus Actions.
 
 For example, to count all visible elements on a page we could listen to individual appear/disappear events to update a counter
 
-```html
-<div class="modal" data-controller="counter" data-action="appear@window->counter#increase disappear@window->counter#decrease" >
+```js{6}
+import { Controller } from '@hotwired/stimulus'
+import { useIntersection } from 'stimulus-use'
+
+export default class extends Controller {
+  connect() {
+    useIntersection(this, { eventPrefix: false })
+  }
+}
+```
+
+```html{4}
+<div
+  class="modal"
+  data-controller="counter"
+  data-action="appear@window->counter#increase disappear@window->counter#decrease"
+>
 </div>
 ```
+
+Since the `data-controller` and the `data-action` are on the same element you can even leave out the `@window` because you don't need to wait for the event to bubble up the DOM tree to the `window`. The event gets dispatched on the controller element (if not overridden by the `element` option).
+
+```html{4}
+<div
+  class="modal"
+  data-controller="counter"
+  data-action="appear->counter#increase disappear->counter#decrease"
+>
+</div>
+```
+
+### Event Details
 
 Get the emitting controller and entry object for an appear event
 
@@ -92,6 +113,17 @@ count(event) {
   const { controller, entry } = event.detail
 }
 ```
+
+## Helper functions
+
+If you are tracking multiple events in your controller you might find these helper functions handy:
+
+| Helper | Description |
+| -------- | ----------- |
+| `this.isVisible()` / `this.allVisible()` | Returns `true` if **all** of the tracked elements are visible. |
+| `this.noneVisible()` | Returns `true` if **none** of the tracked elements are visible. |
+| `this.oneVisible()` | Returns `true` if **exactly one** of the tracked elements is visible. |
+| `this.atLeastOneVisible()` | Returns `true` if **at least one** of the tracked elements is visible. |
 
 
 ## Example

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -2,7 +2,6 @@ import { Controller, Context } from '@hotwired/stimulus'
 import { useIntersection, IntersectionOptions } from './use-intersection'
 
 export class IntersectionComposableController extends Controller {
-  isVisible: boolean = false
   declare appear?: (entry: IntersectionObserverEntry) => void
   declare disappear?: (entry: IntersectionObserverEntry) => void
 }

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -4,6 +4,7 @@ import { useIntersection, IntersectionOptions } from './use-intersection'
 export class IntersectionComposableController extends Controller {
   declare appear?: (entry: IntersectionObserverEntry) => void
   declare disappear?: (entry: IntersectionObserverEntry) => void
+  declare intersectionElements: Element[]
 }
 
 export class IntersectionController extends IntersectionComposableController {

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -5,6 +5,11 @@ export class IntersectionComposableController extends Controller {
   declare appear?: (entry: IntersectionObserverEntry) => void
   declare disappear?: (entry: IntersectionObserverEntry) => void
   declare intersectionElements: Element[]
+  declare isVisible: () => boolean
+  declare noneVisible: () => boolean
+  declare oneVisible: () => boolean
+  declare atLeastOneVisible: () => boolean
+  declare allVisible: () => boolean
 }
 
 export class IntersectionController extends IntersectionComposableController {

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -71,11 +71,7 @@ export const useIntersection = (controller: IntersectionComposableController, op
 
   Object.assign(controller, {
     get isVisible() {
-      if (controller.intersectionElements.length === 1) {
-        return controller.intersectionElements[0].hasAttribute('isVisible')
-      } else {
-        return controller.intersectionElements.every(element => element.hasAttribute('isVisible'))
-      }
+      return controller.intersectionElements.every(element => element.hasAttribute('isVisible'))
     },
     get noneVisible() {
       return controller.intersectionElements.filter(element => element.hasAttribute('isVisible')).length === 0

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -20,13 +20,13 @@ export const useIntersection = (controller: IntersectionComposableController, op
     const [entry] = entries
     if (entry.isIntersecting) {
       dispatchAppear(entry)
-    } else if (targetElement.hasAttribute("isVisible")) {
+    } else if (targetElement.hasAttribute('isVisible')) {
       dispatchDisappear(entry)
     }
   }
 
   const dispatchAppear = (entry: IntersectionObserverEntry) => {
-    targetElement.setAttribute("isVisible", "true")
+    targetElement.setAttribute('isVisible', 'true')
     method(controller, 'appear').call(controller, entry)
 
     // emit a custom "appear" event

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -16,6 +16,10 @@ export const useIntersection = (controller: IntersectionComposableController, op
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
+  if (!controller.intersectionElements) controller.intersectionElements = []
+
+  controller.intersectionElements.push(targetElement)
+
   const callback = (entries: IntersectionObserverEntry[]) => {
     const [entry] = entries
     if (entry.isIntersecting) {
@@ -66,6 +70,25 @@ export const useIntersection = (controller: IntersectionComposableController, op
   }
 
   Object.assign(controller, {
+    get isVisible() {
+      if (controller.intersectionElements.length === 1) {
+        return controller.intersectionElements[0].hasAttribute('isVisible')
+      } else {
+        return controller.intersectionElements.every(element => element.hasAttribute('isVisible'))
+      }
+    },
+    get noneVisible() {
+      return controller.intersectionElements.filter(element => element.hasAttribute('isVisible')).length === 0
+    },
+    get oneVisible() {
+      return controller.intersectionElements.filter(element => element.hasAttribute('isVisible')).length === 1
+    },
+    get atLeastOneVisible() {
+      return controller.intersectionElements.some(element => element.hasAttribute('isVisible'))
+    },
+    get allVisible() {
+      return controller.intersectionElements.every(element => element.hasAttribute('isVisible'))
+    },
     disconnect() {
       unobserve()
       controllerDisconnect()

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -20,13 +20,13 @@ export const useIntersection = (controller: IntersectionComposableController, op
     const [entry] = entries
     if (entry.isIntersecting) {
       dispatchAppear(entry)
-    } else if (controller.isVisible) {
+    } else if (targetElement.hasAttribute("isVisible")) {
       dispatchDisappear(entry)
     }
   }
 
   const dispatchAppear = (entry: IntersectionObserverEntry) => {
-    controller.isVisible = true
+    targetElement.setAttribute("isVisible", "true")
     method(controller, 'appear').call(controller, entry)
 
     // emit a custom "appear" event
@@ -39,7 +39,7 @@ export const useIntersection = (controller: IntersectionComposableController, op
   }
 
   const dispatchDisappear = (entry: IntersectionObserverEntry) => {
-    controller.isVisible = false
+    targetElement.removeAttribute('isVisible')
     method(controller, 'disappear').call(controller, entry)
 
     // emit a custom "disappear" event
@@ -66,7 +66,6 @@ export const useIntersection = (controller: IntersectionComposableController, op
   }
 
   Object.assign(controller, {
-    isVisible: false,
     disconnect() {
       unobserve()
       controllerDisconnect()

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -5,15 +5,17 @@ export interface IntersectionOptions extends IntersectionObserverInit {
   element?: Element
   dispatchEvent?: boolean
   eventPrefix?: boolean | string
+  visibleAttribute?: string
 }
 
 const defaultOptions = {
   dispatchEvent: true,
-  eventPrefix: true
+  eventPrefix: true,
+  visibleAttribute: 'isVisible'
 }
 
 export const useIntersection = (controller: IntersectionComposableController, options: IntersectionOptions = {}) => {
-  const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
+  const { dispatchEvent, eventPrefix, visibleAttribute } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
   if (!controller.intersectionElements) controller.intersectionElements = []
@@ -24,13 +26,13 @@ export const useIntersection = (controller: IntersectionComposableController, op
     const [entry] = entries
     if (entry.isIntersecting) {
       dispatchAppear(entry)
-    } else if (targetElement.hasAttribute('isVisible')) {
+    } else if (targetElement.hasAttribute(visibleAttribute)) {
       dispatchDisappear(entry)
     }
   }
 
   const dispatchAppear = (entry: IntersectionObserverEntry) => {
-    targetElement.setAttribute('isVisible', 'true')
+    targetElement.setAttribute(visibleAttribute, 'true')
     method(controller, 'appear').call(controller, entry)
 
     // emit a custom "appear" event
@@ -43,7 +45,7 @@ export const useIntersection = (controller: IntersectionComposableController, op
   }
 
   const dispatchDisappear = (entry: IntersectionObserverEntry) => {
-    targetElement.removeAttribute('isVisible')
+    targetElement.removeAttribute(visibleAttribute)
     method(controller, 'disappear').call(controller, entry)
 
     // emit a custom "disappear" event
@@ -71,19 +73,19 @@ export const useIntersection = (controller: IntersectionComposableController, op
 
   Object.assign(controller, {
     get isVisible() {
-      return controller.intersectionElements.every(element => element.hasAttribute('isVisible'))
+      return controller.intersectionElements.every(element => element.hasAttribute(visibleAttribute))
     },
     get noneVisible() {
-      return controller.intersectionElements.filter(element => element.hasAttribute('isVisible')).length === 0
+      return controller.intersectionElements.filter(element => element.hasAttribute(visibleAttribute)).length === 0
     },
     get oneVisible() {
-      return controller.intersectionElements.filter(element => element.hasAttribute('isVisible')).length === 1
+      return controller.intersectionElements.filter(element => element.hasAttribute(visibleAttribute)).length === 1
     },
     get atLeastOneVisible() {
-      return controller.intersectionElements.some(element => element.hasAttribute('isVisible'))
+      return controller.intersectionElements.some(element => element.hasAttribute(visibleAttribute))
     },
     get allVisible() {
-      return controller.intersectionElements.every(element => element.hasAttribute('isVisible'))
+      return controller.intersectionElements.every(element => element.hasAttribute(visibleAttribute))
     },
     disconnect() {
       unobserve()

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -71,22 +71,30 @@ export const useIntersection = (controller: IntersectionComposableController, op
     observer.unobserve(targetElement)
   }
 
+  const noneVisible = () => {
+    return controller.intersectionElements.filter(element => element.hasAttribute(visibleAttribute)).length === 0
+  }
+
+  const oneVisible = () => {
+    return controller.intersectionElements.filter(element => element.hasAttribute(visibleAttribute)).length === 1
+  }
+
+  const atLeastOneVisible = () => {
+    return controller.intersectionElements.some(element => element.hasAttribute(visibleAttribute))
+  }
+
+  const allVisible = () => {
+    return controller.intersectionElements.every(element => element.hasAttribute(visibleAttribute))
+  }
+
+  const isVisible = allVisible
+
   Object.assign(controller, {
-    get isVisible() {
-      return controller.intersectionElements.every(element => element.hasAttribute(visibleAttribute))
-    },
-    get noneVisible() {
-      return controller.intersectionElements.filter(element => element.hasAttribute(visibleAttribute)).length === 0
-    },
-    get oneVisible() {
-      return controller.intersectionElements.filter(element => element.hasAttribute(visibleAttribute)).length === 1
-    },
-    get atLeastOneVisible() {
-      return controller.intersectionElements.some(element => element.hasAttribute(visibleAttribute))
-    },
-    get allVisible() {
-      return controller.intersectionElements.every(element => element.hasAttribute(visibleAttribute))
-    },
+    isVisible,
+    noneVisible,
+    oneVisible,
+    atLeastOneVisible,
+    allVisible,
     disconnect() {
       unobserve()
       controllerDisconnect()


### PR DESCRIPTION
As pointed out by @ocarreterom the `useIntersection` mixin would just fire the `disappear` event once when the mixin is being used with multiple elements in the same controller.

This PR fixes this issue by moving the tracking reference from the controller instance to each element which is being tracked.


https://user-images.githubusercontent.com/6411752/183229395-bf4b37b6-16b3-465a-a62d-eee9f43f1c9d.mp4



Resolves #211