### PR TITLE
fix: use-transition default options assignment

### DIFF
--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -47,7 +47,11 @@ export const useTransition = (controller: TransitionComposableController, option
 
   const leaveAfter = parseInt(dataset.leaveAfter || '') || options.leaveAfter || 0
 
-  const { transitioned, hiddenClass, preserveOriginalClass, removeToClasses } = Object.assign({}, defaultOptions, options)
+  const { transitioned, hiddenClass, preserveOriginalClass, removeToClasses } = Object.assign(
+    {},
+    defaultOptions,
+    options
+  )
 
   const controllerEnter = controller.enter?.bind(controller)
   const controllerLeave = controller.leave?.bind(controller)

--- a/src/use-transition/use-transition.ts
+++ b/src/use-transition/use-transition.ts
@@ -47,7 +47,7 @@ export const useTransition = (controller: TransitionComposableController, option
 
   const leaveAfter = parseInt(dataset.leaveAfter || '') || options.leaveAfter || 0
 
-  const { transitioned, hiddenClass, preserveOriginalClass, removeToClasses } = Object.assign(defaultOptions, options)
+  const { transitioned, hiddenClass, preserveOriginalClass, removeToClasses } = Object.assign({}, defaultOptions, options)
 
   const controllerEnter = controller.enter?.bind(controller)
   const controllerLeave = controller.leave?.bind(controller)


### PR DESCRIPTION
I think I found a small bug in this mixin where the `defaultOptions` object was getting overridden with values from callers due how `Object.assign` was being used.

I think the fix is to just assign the defaults and then the caller options to a new object.