### PR TITLE
Mark `useDispatch` as deprecated

### DIFF
--- a/docs/application-controller.md
+++ b/docs/application-controller.md
@@ -29,13 +29,14 @@ export default class extends ApplicationController {
     this.isPreview // true/false if it is a Turbolinks preview
     this.isConnected // true/false if the controller is connected
     this.dispatch("hello") // helper to dispatch a custom event "greet:hello" to other Stimulus controllers
+    // this.dispatch() is deprecated: For more information https://stimulus-use.github.io/stimulus-use/#/use-dispatch?id=migration-guide
   }
 }
 ```
 
 ## Functions
 
-**`dispatch(name, eventArgs)`**: helper function to dispatch events to other Stimulus controllers
+!> **Deprecated**: **`dispatch(name, eventArgs)`**: helper function to dispatch events to other Stimulus controllers
 
 **`metaValue(name)`**: return the value of a meta attribute
 

--- a/docs/application.md
+++ b/docs/application.md
@@ -5,5 +5,5 @@ Global mixins and controllers to enhance your application controller.
 | Mixin| Description |
 |------|-------------|
 |[`useApplication`](./docs/application-controller.md)|a super charged application controller|
-|[`useDispatch`](./docs/use-dispatch.md)|Adds a dispatch helper function to emit custom events. Useful to communicate between different controllers.|
+|[`useDispatch` (Deprecated)](./docs/use-dispatch.md)| Adds a dispatch helper function to emit custom events. Useful to communicate between different controllers. |
 |[`useMeta`](./docs/use-meta.md)|Adds getters to easily access <head> meta values.|

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -29,5 +29,5 @@ Some mixin have a debug option. For those, debug can be turned on locally using 
 Example:
 
 ```js
-useDispatch(this, { debug: true })
+useMatchMedia(this, { debug: true })
 ```

--- a/docs/use-dispatch.md
+++ b/docs/use-dispatch.md
@@ -2,6 +2,32 @@
 
 Adds a `dispatch` helper function to emit custom events. Useful to communicate between different controllers.
 
+
+!> **Deprecated**: `useDispatch()` is deprecated. Please use the built-in `this.dispatch()` function from Stimulus: https://stimulus.hotwired.dev/reference/controllers#cross-controller-coordination-with-events
+
+## Migration guide
+
+Because the `dispatch()` function from Stimulus is very similar, the migration process to the Stimulus version of `dispatch()` should be fairly simple:
+- remove the `useDispatch` import
+- remove the  `useDispatch` initializer
+- wrap your payload in a `detail` object
+
+```js
+  import { Controller } from '@hotwired/stimulus'
+- import { useDispatch } from 'stimulus-use'
+
+  export default class extends Controller {
+    connect() {
+-     useDispatch(this)
+    }
+
+    add() {
+-     this.dispatch('add', { quantity: 1 })
++     this.dispatch('add', { detail: { quantity: 1 } })
+    }
+  }
+```
+
 ## Reference
 
 #### Mixin

--- a/src/stimulus-use.ts
+++ b/src/stimulus-use.ts
@@ -55,6 +55,10 @@ export class StimulusUse {
     this.logger.groupEnd()
   }
 
+  warn = (message: string): void => {
+    this.logger.warn(`%c${this.controller.identifier} %c${message}`, 'color: #3B82F6')
+  }
+
   dispatch = (eventName: string, details: any = {}) => {
     if (this.dispatchEvent) {
       const { event, ...eventDetails } = details

--- a/src/use-dispatch/use-dispatch.ts
+++ b/src/use-dispatch/use-dispatch.ts
@@ -50,7 +50,7 @@ export class UseDispatch extends StimulusUse {
     targetElement.dispatchEvent(event)
 
     warn(
-      'useDispatch() is a deprecated mixin from Stimulus-Use. Please use the built-in this.dispatch() function from Stimulus. You can find more information at: https://stimulus-use.github.io/stimulus-use/#/use-dispatch'
+      '`useDispatch()` is deprecated. Please use the built-in `this.dispatch()` function from Stimulus. You can find more information on how to upgrade at: https://stimulus-use.github.io/stimulus-use/#/use-dispatch'
     )
     log('dispatch', { eventName: eventNameWithPrefix, detail, bubbles, cancelable })
 

--- a/src/use-dispatch/use-dispatch.ts
+++ b/src/use-dispatch/use-dispatch.ts
@@ -32,7 +32,7 @@ export class UseDispatch extends StimulusUse {
   }
 
   dispatch = (eventName: string, detail = {}): CustomEvent => {
-    const { controller, targetElement, eventPrefix, bubbles, cancelable, log } = this
+    const { controller, targetElement, eventPrefix, bubbles, cancelable, log, warn } = this
 
     // includes the emitting controller in the event detail
     Object.assign(detail, { controller })
@@ -49,6 +49,9 @@ export class UseDispatch extends StimulusUse {
     // dispatch the event from the given element or by default from the root element of the controller
     targetElement.dispatchEvent(event)
 
+    warn(
+      'useDispatch() is a deprecated mixin from Stimulus-Use. Please use the built-in this.dispatch() function from Stimulus. You can find more information at: https://stimulus-use.github.io/stimulus-use/#/use-dispatch'
+    )
     log('dispatch', { eventName: eventNameWithPrefix, detail, bubbles, cancelable })
 
     return event


### PR DESCRIPTION
closes #206 

Is the deprecation message good enough?
```
useDispatch() is a deprecated mixin from Stimulus-Use. Please use the built-in dispatch() function from Stimulus: https://stimulus.hotwired.dev/reference/controllers#cross-controller-coordination-with-events
```

Two questions:
1. Should other docs also be updated?
- docs/application-controller.md
- docs/application.md
- docs/debug.md
2. Should a "deprecation" file be created, to track the deprecation cycle? 