### PR TITLE
Trigger clickOutside first!

### DIFF
--- a/src/use-click-outside/use-click-outside.ts
+++ b/src/use-click-outside/use-click-outside.ts
@@ -44,13 +44,13 @@ export const useClickOutside = (composableController: Controller, options: Click
 
   const observe = () => {
     events?.forEach(event => {
-      window.addEventListener(event, onEvent, false)
+      window.addEventListener(event, onEvent, true)
     })
   }
 
   const unobserve = () => {
     events?.forEach(event => {
-      window.removeEventListener(event, onEvent, false)
+      window.removeEventListener(event, onEvent, true)
     })
   }
 


### PR DESCRIPTION
I'm having this funny issue with states when playing with elements that are shown/hidden by an "outsider" element. 

```html
<div id="sidebar" data-controller="sidebar"></div>
<div id="burger"></div>
```

The `burger` element opens the sidebar, being outside the sidebar controller/element scope. The `sidebar` controller uses `clickOutside` to close/hide the sidebar if it's open. When clicking the burger, it changes the state of the sidebar and opens it making it visible with in the viewport. And then `clickOutside` is triggered closing it again (as it's visible within the viewport now and the state has just changed). `open -> clickOutside -> close`

As workaround I've been adding a delay of 1ms to execute the lines that changes the state of the sidebar, then `clickOutside` don't even trigger as the sidebar it's not visible or the state hasn't changed neither.

But I think `capture` the click event and trigger `clickOutside` first is the way to go, as this will make this events trigger before any changes on the controller element state or visibility done, if any, by an "outsider" element. And I don't see any case then capturing the event could cause issues.