### PR TITLE
Add `overwriteDispatch` option to `useApplication()`

### DIFF
--- a/docs/application-controller.md
+++ b/docs/application-controller.md
@@ -2,6 +2,21 @@
 
 This is a supercharged Stimulus Controller. You can extend all of your Stimulus controllers from this one and access a few handy functions everywhere.
 
+## Reference
+
+```javascript
+useApplication(controller, options = {})
+```
+
+**controller:** A Stimulus Controller (usually `'this'`)
+
+**options:**
+
+| Option| Description | Default value |
+|-----------------------|-------------|---------------------|
+| `overwriteDispatch` | Whether to call the deprecated `useDispatch()` on the controller or not. | `true` |
+
+
 ## Usage
 
 **Composing**
@@ -42,7 +57,7 @@ export default class extends ApplicationController {
 
 **Getters**
 
-**`isPreview`**: returns `true`/`false` whether the current page is a Turbolinks preview. [Use case for playing animations with Turbolinks](https://dev.to/adrienpoly/animations-with-turbolinks-and-stimulus-4862)
+**`isPreview`**: returns `true`/`false` whether the current page is a Turbo/Turbolinks preview. [Use case for playing animations with Turbolinks](https://dev.to/adrienpoly/animations-with-turbolinks-and-stimulus-4862)
 
 **`isConnected`**: returns `true`/`false` for whether the Stimulus controller is connected or not.
 

--- a/src/use-application/use-application.ts
+++ b/src/use-application/use-application.ts
@@ -1,7 +1,17 @@
 import { Controller } from '@hotwired/stimulus'
 import { useDispatch, DispatchOptions } from '../use-dispatch/index'
 
-export const useApplication = (controller: Controller, options: DispatchOptions = {}) => {
+export type ApplicationOptions = DispatchOptions & {
+  overwriteDispatch?: boolean
+}
+
+const defaultOptions: ApplicationOptions = {
+  overwriteDispatch: true
+}
+
+export const useApplication = (controller: Controller, options: ApplicationOptions = {}) => {
+  const { overwriteDispatch } = Object.assign({}, defaultOptions, options)
+
   // getter to detect Turbolinks preview
   Object.defineProperty(controller, 'isPreview', {
     get(): boolean {
@@ -26,7 +36,9 @@ export const useApplication = (controller: Controller, options: DispatchOptions 
     }
   })
 
-  useDispatch(controller, options)
+  if (overwriteDispatch) {
+    useDispatch(controller, options)
+  }
 
   Object.assign(controller, {
     metaValue(name: string) {


### PR DESCRIPTION
This Pull Request adds a `overwriteDispatch` option to `useApplication()` in order to be able to control if `useApplication` should call the deprecated `useDispatch()` behavior or not. 

Previously if you were using `useApplication()` it would always override the built-in Stimulus `this.dispatch()` function inside the controller.

The `overwriteDispatch` option is set to `true` by default so that it doesn't break backwards-compatibility, but you probably anyway just want to call `useApplication()` with this option if you want to disable the overwrite:

```js
import { Controller } from "@hotwired/stimulus"
import { useApplication } from "stimulus-use"

export default class extends Controller {
  connect() {
    useApplication(this, { overwriteDispatch: false })
  }
}
```
