### PR TITLE
Add basic development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ export default class extends IntersectionController {
 }
 ```
 
+## Development
+
+- Fork the project locally
+- `yarn install`
+- `yarn start` - to run the local dev server with examples
+- `yarn test` - to run the unit tests
+- `yarn lint` - to run the linter with ESLint
+- `yarn format` - to format changes with Prettier
+- `yarn build` - to bundle the app into static files for production
 
 
 ## Contributors ✨


### PR DESCRIPTION
While trying to look into an issue (#177) I found no available development documentation to get started fixing bugs, 
so I tried the one from stimulus.

While the `yarn start` command fails for me, I could get started using the other commands.

