### PR TITLE
`useHotKeys`: Allow unbinding hotkeys within a scope if provided

### DIFF
--- a/src/use-hotkeys/use-hotkeys.ts
+++ b/src/use-hotkeys/use-hotkeys.ts
@@ -49,8 +49,10 @@ export class UseHotkeys extends StimulusUse {
   }
 
   unbind = () => {
-    for (const hotkey in this.hotkeysOptions.hotkeys as any) {
-      hotkeys.unbind(hotkey)
+    for (const [hotkey, definition] of Object.entries(this.hotkeysOptions.hotkeys as any)) {
+      const options = (definition as HotkeyDefinition).options
+      const scope = options.scope ? options.scope : ''
+      hotkeys.unbind(hotkey, scope)
     }
   }
 


### PR DESCRIPTION
This partially fixes #177 , as it at least now allows to unbind the shortcuts within a scope if one has been provided.

## Example 

```hotkey_controller.js
import { Controller } from "@hotwired/stimulus";
import { useHotkeys, useThrottle } from "stimulus-use";

export default class extends Controller {
  static values = { key: String, scope: { type: String, default: "app" } };
  static throttles = ["fire"];
  connect() {
    useThrottle(this, { wait: 2000 });
    hotkeys = {};
    hotkeys[this.keyValue] = { handler: this.fire, options: { scope: this.scopeValue } };
    useHotkeys(this, { hotkeys: hotkeys });
  }

  fire() {
    this.element.click();
  }
}

```

```html

<button data-action="dialog#close" data-controller="hotkey" data-hotkey-scope-value="preview" data-hotkey-key-value="Esc" type="button">
  Close
</button>


<button data-action="selection#empty" data-controller="hotkey" data-hotkey-scope-value="selection" data-hotkey-key-value="Esc" type="button">
  Empty selection
</button>
```

So when Closing the dialog, the `Esc` key gets unbound correctly, while the Empty selection hotkey will still work.