### PR TITLE
`useDispatch`: Fix params for debounced actions if event is shared

### DIFF
--- a/spec/use-debounce/fixtures.js
+++ b/spec/use-debounce/fixtures.js
@@ -3,3 +3,9 @@ export const fixtureBase = `
     <div id="debounced" data-action="click->debounce#a click->debounce#b click->debounce#c"></div>
   </div>
 `
+
+export const sameEventMultipleActions = `
+  <div data-controller="debounce" data-action="click@window->debounce#b">
+    <button id="debounced" data-debounce-some-id-param="123" data-action="click->debounce#a">Click me</button>
+  </div>
+`

--- a/spec/use-debounce/use_log_controller.js
+++ b/spec/use-debounce/use_log_controller.js
@@ -8,15 +8,28 @@ export default class UseLogController extends Controller {
     useDebounce(this, this.application.options)
   }
 
-  a() {
-    this.application.testLogger.log({ name: 'a' })
+  a(event) {
+    this.recordAction('a', event)
   }
 
-  b() {
-    this.application.testLogger.log({ name: 'b' })
+  b(event) {
+    this.recordAction('b', event)
   }
 
-  c() {
-    this.application.testLogger.log({ name: 'c' })
+  c(event) {
+    this.recordAction('c', event)
+  }
+
+  recordAction(name, event, passive = null) {
+    this.application.testLogger.log({
+      name,
+      controller: this,
+      identifier: this.identifier,
+      eventType: event.type,
+      currentTarget: event.currentTarget,
+      params: event.params,
+      defaultPrevented: event.defaultPrevented,
+      passive: passive || false
+    })
   }
 }

--- a/src/use-debounce/index.ts
+++ b/src/use-debounce/index.ts
@@ -1,1 +1,1 @@
-export { useDebounce } from './use-debounce'
+export { useDebounce, debounce } from './use-debounce'

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -11,14 +11,18 @@ class DebounceController extends Controller {
 
 const defaultWait = 200
 
-const debounce = (fn: Function, wait: number = defaultWait) => {
+export const debounce = (fn: Function, wait: number = defaultWait) => {
   let timeoutId: ReturnType<typeof setTimeout> | null = null
 
   return function (this: any): any {
-    const args = arguments
+    const args = Array.from(arguments)
     const context = this
+    const params = args.map(arg => arg.params)
 
-    const callback = () => fn.apply(context, args)
+    const callback = () => {
+      args.forEach((arg, index) => (arg.params = params[index]))
+      return fn.apply(context, args)
+    }
     if (timeoutId) {
       clearTimeout(timeoutId)
     }


### PR DESCRIPTION
The way Stimulus invokes controller actions doesn't account for debounced actions. Since stimulus-use is rewriting the actual controller action of the Controller and therefore also executing the action after the specifed debounce time, there is enough time for the browser the re-assign the `params` object on the `event`.

But this actually just happened and mattered if the same actual event was used for triggering multiple actions, the order was right and the controller action relied on the `event.params` to be right.

Context:
https://github.com/hotwired/stimulus/blob/38cefb4cad01e8af9288cad1a1fedb41b3b1383a/src/core/binding.ts#L72

Fixes #251 

Special thanks to @KonnorRogers for rubber ducking this issue! ❤️ 

I had a few solutions which fixed this issue upstream in Stimulus itself, but I figured out that none of them were good enough or didn't break other stuff - so I decided to fix it in stimulus-use, because this is also the place where the controller action actually gets overridden.

/cc @sc0ttman