### PR TITLE
Extract `useHotkeys()` and remove `hotkeys-js` as dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 tsconfig.json
 webpack.config.js
 *.log
+*~
 karma.conf.js
 yarn-error.log
 /.git

--- a/docs/use-hotkeys.md
+++ b/docs/use-hotkeys.md
@@ -1,16 +1,29 @@
 # useHotkeys
 
-Adds one new behavior to your Stimulus controller : `useHotkeys`
+The `useHotkeys` behavior can be used to register hotkeys using the [hotkeys-js](https://wangchujiang.com/hotkeys/) library. To use it, do the following:
 
-This behavior can be used to register hotkeys using the [hotkeys-js](https://wangchujiang.com/hotkeys/) library. To use it, do the following:
-
-1. Install the hotkeys-js peer dependency:
+1. Install the `hotkeys-js` peer dependency:
 
 ```bash
-$ yarn add hotkeys-js
+yarn add hotkeys-js
+```
+
+```bash
+bin/importmap pin hotkeys-js
 ```
 
 2. Define hotkeys and respective handlers and pass them as an argument to `useHotkeys`.
+
+## Importing the behavior
+
+!> **Note**: `stimulus-use` version `0.52.0` changed the way how this behavior needs to be imported in your application.
+
+```diff
+- import { useHotkeys } from "stimulus-use"
++ import { useHotkeys } from "stimulus-use/hotkeys"
+```
+
+**Also, please add `hotkeys-js` as a npm dependency to your application if you haven't added it yet, version `0.52.0` removed it as a dependency.**
 
 ## Reference
 
@@ -22,13 +35,13 @@ useHotkeys(controller, options)
 
 **options** : Hotkey definitions, in simple or advanced format (see examples below)
 
-*simple:* 
+*simple:*
 
 ```typescript
 { [hotkey: string]: [handler: KeyHandler, element: HTMLElement] }
 ```
 
-*advanced:* 
+*advanced:*
 ```typescript
 {
   hotkeys?: {
@@ -52,7 +65,7 @@ useHotkeys(controller, options)
 ### Simple Hotkey Definition
 ```js
 import { Controller } from '@hotwired/stimulus'
-import { useHotkeys } from 'stimulus-use'
+import { useHotkeys } from 'stimulus-use/hotkeys'
 
 export default class extends Controller {
   connect() {
@@ -65,12 +78,12 @@ export default class extends Controller {
   }
 }
 ```
-    
-    
+
+
 ### Advanced Hotkey Definition
 ```js
 import { Controller } from '@hotwired/stimulus'
-import { useHotkeys } from 'stimulus-use'
+import { useHotkeys } from 'stimulus-use/hotkeys'
 
 export default class extends Controller {
   connect() {

--- a/package.json
+++ b/package.json
@@ -2,15 +2,36 @@
   "name": "stimulus-use",
   "version": "0.51.3",
   "description": "A collection of standard controllers and utilities for Stimulus",
-  "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "unpkg": "dist/index.umd.js",
-  "types": "dist/types/index.d.ts",
-  "amdName": "StimulusUse",
-  "author": "@adrienpoly",
+  "repository": "https://github.com/stimulus-use/stimulus-use",
   "license": "MIT",
-  "external": "@hotwired/stimulus",
+  "author": "Adrien Poly",
+  "contributors": [
+    "Adrien Poly",
+    "Marco Roth"
+  ],
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "unpkg": "./dist/index.umd.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "main": "./dist/index.umd.js",
+      "browser": "./dist/index.js",
+      "import": "./dist/index.js",
+      "module": "./dist/index.js",
+      "umd": "./dist/index.umd.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./hotkeys": {
+      "main": "./dist/hotkeys.umd.js",
+      "browser": "./dist/hotkeys.js",
+      "import": "./dist/hotkeys.js",
+      "module": "./dist/hotkeys.js",
+      "umd": "./dist/hotkeys.umd.js",
+      "types": "./dist/types/hotkeys.d.ts"
+    }
+  },
   "scripts": {
     "prestart": "cd playground && yarn install && cd -",
     "start": "cd playground && yarn start",
@@ -43,6 +64,7 @@
     "chai-dom": "^1.8.2",
     "cypress": "^12.3.0",
     "docsify-cli": "^4.4.4",
+    "hotkeys-js": "^3.10.1",
     "html2js": "^0.2.0",
     "intersection-observer": "^0.12.2",
     "karma": "^6.1.0",
@@ -72,14 +94,8 @@
     "typescript": "^3.9.7",
     "webpack": "^4.44.1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/stimulus-use/stimulus-use"
-  },
   "peerDependencies": {
-    "@hotwired/stimulus": ">= 3"
-  },
-  "dependencies": {
-    "hotkeys-js": ">=3"
+    "@hotwired/stimulus": ">= 3",
+    "hotkeys-js": ">= 3"
   }
 }

--- a/playground/controllers/hotkeys_controller.js
+++ b/playground/controllers/hotkeys_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { useHotkeys } from 'stimulus-use'
+import { useHotkeys } from 'stimulus-use/hotkeys'
 
 export default class extends Controller {
   static targets = ['overlay']

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      'stimulus-use': path.resolve(__dirname, '../dist/index.js')
+      'stimulus-use': path.resolve(__dirname, '../dist/')
     }
   },
   plugins: []

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ const banner = `/*\nStimulus-Use ${version}\n*/`
 export default [
   {
     input: 'src/index.ts',
-    external: ['@hotwired/stimulus', 'hotkeys-js'],
+    external: ['@hotwired/stimulus'],
     output: [
       {
         name: 'StimulusUse',
@@ -17,8 +17,7 @@ export default [
         format: 'umd',
         banner,
         globals: {
-          '@hotwired/stimulus': 'Stimulus',
-          'hotkeys-js': 'hotkeys'
+          '@hotwired/stimulus': 'Stimulus'
         }
       },
       {
@@ -30,6 +29,31 @@ export default [
     plugins: [resolve(), typescript(), filesize()],
     watch: {
       include: 'src/**'
+    }
+  },
+  {
+    input: 'src/hotkeys.ts',
+    external: ['@hotwired/stimulus', 'hotkeys-js'],
+    output: [
+      {
+        name: 'StimulusUseHotkeys',
+        file: 'dist/hotkeys.umd.js',
+        format: 'umd',
+        banner,
+        globals: {
+          '@hotwired/stimulus': 'Stimulus',
+          'hotkeys-js': 'hotkeys'
+        }
+      },
+      {
+        file: 'dist/hotkeys.js',
+        format: 'es',
+        banner
+      }
+    ],
+    plugins: [resolve(), typescript(), filesize()],
+    watch: {
+      include: ['src/hotkeys.ts', 'src/use-hotkeys/**/*']
     }
   }
 ]

--- a/spec/use-hotkeys/use_log_controller.js
+++ b/spec/use-hotkeys/use_log_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { useHotkeys } from '../../src'
+import { useHotkeys } from '../../src/hotkeys'
 
 class UseLogController extends Controller {
   static targets = ['input']

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -1,0 +1,1 @@
+export * from './use-hotkeys'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ export * from './use-application'
 export * from './use-click-outside'
 export * from './use-debounce'
 export * from './use-dispatch'
-export * from './use-hotkeys'
 export * from './use-hover'
 export * from './use-idle'
 export * from './use-intersection'
@@ -18,3 +17,7 @@ export * from './use-transition'
 export * from './use-visibility'
 export * from './use-window-focus'
 export * from './use-window-resize'
+
+export function useHotkeys() {
+  throw '[stimulus-use] Notice: The import for `useHotkeys()` has been moved from `stimulus-use` to `stimulus-use/hotkeys`. \nPlease change the import accordingly and add `hotkey-js` as a dependency to your project. \n\nFor more information see: https://stimulus-use.github.io/stimulus-use/#/use-hotkeys?id=importing-the-behavior'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4460,10 +4460,10 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
-hotkeys-js@>=3:
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.8.7.tgz#c16cab978b53d7242f860ca3932e976b92399981"
-  integrity sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==
+hotkeys-js@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.10.1.tgz#0c67e72298f235c9200e421ab112d156dc81356a"
+  integrity sha512-mshqjgTqx8ee0qryHvRgZaZDxTwxam/2yTQmQlqAWS3+twnq1jsY9Yng9zB7lWq6WRrjTbTOc7knNwccXQiAjQ==
 
 html-escaper@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
This pull request moves the `useHotkeys()` behavior to separate file, so that the main bundle doesn't include `hotkeys-js` as a NPM dependency.

If you are using `useHotkeys()` in your application and you are upgrading to the next version (likely `v0.52.0`) you have to change the import for the `useHotkeys()` behavior.

```diff
-import { useHotkeys } from "stimulus-use"
+import { useHotkeys } from "stimulus-use/hotkeys"
```

Also, please add `hotkeys-js` as a npm dependency to your application if you haven't added it yet, it's not being removed as a runtime  dependency.

The existing import (`import { useHotkeys } from "stimulus-use"`) will throw an error in the new version, so that people know how to upgrade (if we don't throw the error here it would throw an error down the stack, because the `import "hotkeys-js"` would fail):

![Screenshot 2023-01-14 at 18 31 54](https://user-images.githubusercontent.com/6411752/212487015-4ab17d9e-d782-44e8-a5f6-2b6249261e87.png)





Resolves #237 