### PR TITLE
Pass `IntersectionObserver` instance to `useIntersection` callbacks

### DIFF
--- a/docs/use-intersection.md
+++ b/docs/use-intersection.md
@@ -1,6 +1,6 @@
 # useIntersection
 
-Adds 2 new behaviors to your Stimulus controller : `appear` and `disappear`.
+Adds 2 new behaviors to your Stimulus controller: `appear` and `disappear`.
 
 This behavior is built on top of the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
 
@@ -45,12 +45,12 @@ export default class extends Controller {
     useIntersection(this)
   }
 
-  appear(entry) {
+  appear(entry, observer) {
     // callback automatically triggered when the element
     // intersects with the viewport (or root Element specified in the options)
   }
 
-  disappear(entry) {
+  disappear(entry, observer) {
     // callback automatically triggered when the element
     // leaves the viewport (or root Element specified in the options)
   }
@@ -67,11 +67,11 @@ export default class extends IntersectionController {
     element: this.element, // default
   }
 
-  appear(entry) {
+  appear(entry, observer) {
     // ...
   }
 
-  disappear(entry) {
+  disappear(entry, observer) {
     // ...
   }
 }
@@ -124,7 +124,7 @@ Get the emitting controller and entry object for an appear event
 
 ```js
 count(event) {
-  const { controller, entry } = event.detail
+  const { controller, entry, observer } = event.detail
 }
 ```
 
@@ -165,6 +165,47 @@ export default class extends Controller {
   }
 }
 ```
+
+## Manually calling `observe()` and `unobserve()`
+
+You can manually call `observe()` and `unobserve()` by obtaining references from the `useIntersection()` function call.
+
+`useIntersection()` returns an array with two functions, the first one is the `observe()` and the second one is the `unobserve()` function.
+
+```js
+export default class extends Controller {
+  connect() {
+    const [observe, unobserve] = useIntersection(this)
+    this.observe = observe
+    this.unobserve = unobserve
+  }
+
+  appear() {
+    // observe and emit `appear()` callback just once
+    this.unobserve()
+  }
+}
+```
+
+
+## Accessing the `IntersectionObserver` instance
+
+You have the freedom to perform more advanced operations on the observer directly, so you can customize the logic according to your needs. The `IntersectionObserver` instance gets passed in as the second argument to the `appear` and `disappear` callbacks.
+
+```js
+export default class extends Controller {
+  connect() {
+    useIntersection(this)
+  }
+
+  appear(entry, observer) {
+    // observe and emit `appear()` callback just once
+    observer.unobserve(entry.target)
+  }
+}
+```
+
+Alternatively, you can also access the `observer` from the event detail.
 
 ## Example
 

--- a/src/use-intersection/intersection-controller.ts
+++ b/src/use-intersection/intersection-controller.ts
@@ -2,8 +2,8 @@ import { Controller, Context } from '@hotwired/stimulus'
 import { useIntersection, IntersectionOptions } from './use-intersection'
 
 export class IntersectionComposableController extends Controller {
-  declare appear?: (entry: IntersectionObserverEntry) => void
-  declare disappear?: (entry: IntersectionObserverEntry) => void
+  declare appear?: (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void
+  declare disappear?: (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void
   declare intersectionElements: Element[]
   declare isVisible: () => boolean
   declare noneVisible: () => boolean

--- a/src/use-intersection/use-intersection.ts
+++ b/src/use-intersection/use-intersection.ts
@@ -33,28 +33,30 @@ export const useIntersection = (composableController: Controller, options: Inter
     }
   }
 
+  const observer = new IntersectionObserver(callback, options)
+
   const dispatchAppear = (entry: IntersectionObserverEntry) => {
     targetElement.setAttribute(visibleAttribute, 'true')
-    method(controller, 'appear').call(controller, entry)
+    method(controller, 'appear').call(controller, entry, observer)
 
     // emit a custom "appear" event
     if (dispatchEvent) {
       const eventName = composeEventName('appear', controller, eventPrefix)
 
-      const appearEvent = extendedEvent(eventName, null, { controller, entry })
+      const appearEvent = extendedEvent(eventName, null, { controller, entry, observer })
       targetElement.dispatchEvent(appearEvent)
     }
   }
 
   const dispatchDisappear = (entry: IntersectionObserverEntry) => {
     targetElement.removeAttribute(visibleAttribute)
-    method(controller, 'disappear').call(controller, entry)
+    method(controller, 'disappear').call(controller, entry, observer)
 
     // emit a custom "disappear" event
     if (dispatchEvent) {
       const eventName = composeEventName('disappear', controller, eventPrefix)
 
-      const disappearEvent = extendedEvent(eventName, null, { controller, entry })
+      const disappearEvent = extendedEvent(eventName, null, { controller, entry, observer })
       targetElement.dispatchEvent(disappearEvent)
     }
   }
@@ -63,7 +65,10 @@ export const useIntersection = (composableController: Controller, options: Inter
   // to support composing several behaviors
   const controllerDisconnect = controller.disconnect.bind(controller)
 
-  const observer = new IntersectionObserver(callback, options)
+  const disconnect = () => {
+    unobserve()
+    controllerDisconnect()
+  }
 
   const observe = () => {
     observer.observe(targetElement)
@@ -97,10 +102,7 @@ export const useIntersection = (composableController: Controller, options: Inter
     oneVisible,
     atLeastOneVisible,
     allVisible,
-    disconnect() {
-      unobserve()
-      controllerDisconnect()
-    }
+    disconnect
   })
 
   observe()


### PR DESCRIPTION
This pull request allows the callbacks from the `useIntersection` behavior to access the `IntersectionObserver` as the second argument in the callback.

This enables things like this:
```js
export default class extends Controller { 
  connect() {
    useIntersection(this)
  }
  
  appear(entry, observer) {  
    observer.unobserve(entry.target)
  }
}
```

This allows you to call all available methods directly on the `observer` itself to implement the logic according to your needs. In this case it would allow to only trigger the `appear` callback once.

This enables a more elegant solution for https://github.com/stimulus-use/stimulus-use/issues/370