### PR TITLE
fix: convert html syntax to markdown syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
   <img src="docs/assets/stimulus-use-logo.png" width="500" srcset="docs/assets/stimulus-use-logo@2x.png 2x, docs/assets/stimulus-use-logo@3x.png 3x" />
 </p>
 
-<p align="center">
-  <b>A collection of composable behaviors for your Stimulus Controllers</b>
-  </br>
-  </br>
-  <img src="https://badgen.net/npm/v/stimulus-use" alt="npm version">
-  <a href="https://bundlephobia.com/result?p=stimulus-use" rel="nofollow">
-    <img src="https://badgen.net/bundlephobia/minzip/stimulus-use" alt="minified + gzip size">
-  </a>
-  <img src="https://badgen.net/npm/types/tslib" alt="types included">
-  <img src="https://badgen.net/npm/license/stimulus-use" alt="types included">
-  <img src="./docs/assets/example-buildstatus-badge.png" alt="Sauce test status">
-</p>
+<div align="center">
+
+  **A collection of composable behaviors for your Stimulus Controllers**
+
+  [![npm version](https://badgen.net/npm/v/stimulus-use)](https://npmjs.com/package/stimulus-use)
+  [![minified + gzip size](https://badgen.net/bundlephobia/minzip/stimulus-use)](https://bundlephobia.com/result?p=stimulus-use)
+  ![types included](https://badgen.net/npm/types/tslib)
+  ![license](https://badgen.net/npm/license/stimulus-use)
+  ![Sauce test status](./docs/assets/example-buildstatus-badge.png)
+
+</div>
 <br />
 
 <p align="center">


### PR DESCRIPTION
Converting to markdown syntax removes the underline you can see in the attached screenshot! it's a small detail but I find it really annoying! 
before:
![Screenshot 2023-11-30 at 11 21 20 PM](https://github.com/stimulus-use/stimulus-use/assets/84993125/064aaacb-26fa-4a4c-a862-65bcc40dde83)

after:
![Screenshot 2023-11-30 at 11 29 38 PM](https://github.com/stimulus-use/stimulus-use/assets/84993125/7048fbb0-80ed-4324-a055-8f748739703f)
