### PR TITLE
Fix broken links to hotkeys-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We got you covered 👉 [stimulus-use.github.io/stimulus-use](https://stimulus-u
   | Mixin | Description | NEW Callbacks |
   |-----------------------|-------------|---------------------|
   |[`useClickOutside`](./docs/use-click-outside.md)|Tracks the clicks outside of the element and adds a new lifecycle callback **clickOutside**.|`clickOutside`|
-  |[`useHotkeys`](./docs/use-hotkeys.md)|Registers hotkeys using the [hotkeys-js](https://wangchujiang.com/hotkeys/) library and binds them to handler methods||
+  |[`useHotkeys`](./docs/use-hotkeys.md)|Registers hotkeys using the [hotkeys-js](https://wangchujiang.com/hotkeys-js/) library and binds them to handler methods||
   |[`useHover`](./docs/use-hover.md)|Tracks the user's mouse movements over an element and adds **mouseEnter** and **mouseLeave** callbacks to your controller.|`mouseEnter` `mouseLeave`|
   |[`useIdle`](./docs/use-idle.md)| Tracks if the user is idle on your page and adds **away** and **back** callbacks to your controller.|`away`</br> `back`|
   |[`useIntersection`](./docs/use-intersection.md) | Tracks the element's intersection and adds **appear**, **disappear** callbacks to your controller.|`appear`</br> `disappear`|

--- a/docs/use-hotkeys.md
+++ b/docs/use-hotkeys.md
@@ -1,6 +1,6 @@
 # useHotkeys
 
-The `useHotkeys` behavior can be used to register hotkeys using the [hotkeys-js](https://wangchujiang.com/hotkeys/) library. To use it, do the following:
+The `useHotkeys` behavior can be used to register hotkeys using the [hotkeys-js](https://wangchujiang.com/hotkeys-js/) library. To use it, do the following:
 
 1. Install the `hotkeys-js` peer dependency:
 


### PR DESCRIPTION
I noticed that the links to the Hotkeys-js library were broken, so I fixed them.
It might be interesting to link directly to the Github repository rather than the official site? what do you think? 
I'll make the change if you prefer.