### PR TITLE
Fix minor errors in use-target-mutation doc

### DIFF
--- a/docs/use-target-mutation.md
+++ b/docs/use-target-mutation.md
@@ -122,12 +122,13 @@ export default class extends TargetMutationController {
   }
 
   locationTargetChanged(element) {
-    // triggered when a locationTarget is removed
+    // triggered when a locationTarget is changed
   }
 
 }
 ```
-**Extending a controller with options **
+
+**Extending a controller with options**
 
 ```js
 import { TargetMutationController } from 'stimulus-use'
@@ -146,7 +147,7 @@ export default class extends TargetMutationController {
   }
 
   locationTargetChanged(element) {
-    // triggered when a locationTarget is removed
+    // triggered when a locationTarget is changed
   }
 
 }


### PR DESCRIPTION
Doc had spaces between bold markdown symbols, resulting it displaying ** ** instead of actual bold text. Also changed instances of the word 'removed' to 'changed' for clarity to match the appropriate method.

I would also suggest using header markdown symbols instead of bolding the titles where appropriate.