### PR TITLE
Extra type safety check in use-click-outside

### DIFF
--- a/src/use-click-outside/use-click-outside.ts
+++ b/src/use-click-outside/use-click-outside.ts
@@ -24,7 +24,10 @@ export const useClickOutside = (composableController: Controller, options: Click
   const onEvent = (event: Event) => {
     const targetElement: Element = options?.element || controller.element
 
-    if (event.target instanceof Node && targetElement.contains(event.target as Node) || (!isElementInViewport(targetElement) && onlyVisible)) {
+    if (
+      (event.target instanceof Node && targetElement.contains(event.target as Node)) ||
+      (!isElementInViewport(targetElement) && onlyVisible)
+    ) {
       return
     }
 

--- a/src/use-click-outside/use-click-outside.ts
+++ b/src/use-click-outside/use-click-outside.ts
@@ -24,7 +24,7 @@ export const useClickOutside = (composableController: Controller, options: Click
   const onEvent = (event: Event) => {
     const targetElement: Element = options?.element || controller.element
 
-    if (targetElement.contains(event.target as Node) || (!isElementInViewport(targetElement) && onlyVisible)) {
+    if (event.target instanceof Node && targetElement.contains(event.target as Node) || (!isElementInViewport(targetElement) && onlyVisible)) {
       return
     }
 


### PR DESCRIPTION
I'm seeing cases where an error arises from assuming `event.target` is always a `Node`:

```
TypeError: Argument 1 ('other') to Node.contains must be an instance of Node
```

I'd like to propose adding an extra check here so it doesn't fail if it is `Window` for instance.