### PR TITLE
fix: forward ElementType generic to Controller

### DIFF
--- a/src/use-application/application-controller.ts
+++ b/src/use-application/application-controller.ts
@@ -2,7 +2,7 @@ import { Controller, Context } from '@hotwired/stimulus'
 import { useApplication } from './use-application'
 import { DispatchOptions } from '../use-dispatch'
 
-export class ApplicationController extends Controller {
+export class ApplicationController<ElementType extends Element = Element> extends Controller<ElementType> {
   options?: DispatchOptions
   readonly isPreview: boolean = false
   readonly isConnected: boolean = false


### PR DESCRIPTION
## What

`ApplicationController` extends Stimulus `Controller` without forwarding the `ElementType` generic parameter, so `this.element` is always typed as `Element`. Subclasses cannot narrow it (e.g. to `HTMLFormElement`) without a cast.

This adds the generic parameter and forwards it to `Controller<ElementType>`:

```ts
export class ApplicationController<ElementType extends Element = Element> extends Controller<ElementType> {
```

## Usage

```ts
class FormController extends ApplicationController<HTMLFormElement> {
  submit() {
    this.element.requestSubmit() // typed, no cast
  }
}
```

## Compatibility

The default `= Element` preserves backward compatibility — existing `extends ApplicationController` is unaffected.

## Verification

- `tsc` typecheck passes; emitted `.d.ts` declares the generic.
- Full test suite passes (123/123).

Closes #583