### PR TITLE
fix: silence karma TS18028 and reload errors

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -91,6 +91,18 @@ module.exports = function (config) {
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['karma-typescript', 'mocha', 'sinon-chai', 'fixture'],
 
+    // Scope karma-typescript to our source only. Without this it walks
+    // node_modules and compiles dependency typings (e.g. puppeteer) at its
+    // default low target, emitting TS18028 errors for their `#private` fields.
+    karmaTypescriptConfig: {
+      compilerOptions: {
+        target: 'es2017',
+        module: 'commonjs',
+        lib: ['dom', 'es2017']
+      },
+      exclude: ['node_modules']
+    },
+
     // list of files / patterns to load in the browser
     files: [
       'spec/**/*_spec.js',
@@ -148,7 +160,10 @@ module.exports = function (config) {
       chai: {
         includeStack: true
       },
-      clearContext: false
+      // Default (true) clears the context between runs. `false` is only for
+      // interactive `karma start` debugging; under headless singleRun it makes
+      // Karma flag a false-positive "full page reload" and exit with an error.
+      clearContext: true
     },
 
     // test results reporter to use

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -83,6 +83,10 @@ module.exports = function (config) {
   //   process.exit(1)
   // }
 
+  // `test:watch` runs `karma start --no-single-run` for interactive debugging.
+  // CI (`yarn test`) runs single-run and must exit cleanly.
+  const singleRun = !process.argv.includes('--no-single-run')
+
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
@@ -160,10 +164,10 @@ module.exports = function (config) {
       chai: {
         includeStack: true
       },
-      // Default (true) clears the context between runs. `false` is only for
-      // interactive `karma start` debugging; under headless singleRun it makes
-      // Karma flag a false-positive "full page reload" and exit with an error.
-      clearContext: true
+      // Keep the runner context only for interactive watch debugging. Under
+      // headless singleRun, `false` makes Karma flag a false-positive "full
+      // page reload" and exit with an error, so clear it there.
+      clearContext: singleRun
     },
 
     // test results reporter to use
@@ -209,7 +213,7 @@ module.exports = function (config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
+    singleRun
   })
 
   // if (process.env.CI) {


### PR DESCRIPTION
## Problem

`yarn test` passes all specs but the runner prints errors and exits non-zero, masking real failures in CI:

```
ERROR [compiler.karma-typescript]: node_modules/puppeteer/lib/types.d.ts(...): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
...
Chrome Headless ERROR
  Some of your tests did a full page reload!
```

Both are config-level, not test-level (an empty single test reproduces the reload error; the TS18028 noise comes from dependency typings).

## Root causes & fixes

**1. TS18028 from puppeteer typings**
`karma.conf.js` had no `karmaTypescriptConfig`, so karma-typescript walked `node_modules` and compiled dependency `.d.ts` files (puppeteer) at its default low target — puppeteer's `#private` fields then error. Scoped compilation to our source with `target: es2017` and `exclude: ['node_modules']`.

**2. "Some of your tests did a full page reload!"**
`client.clearContext: false` is only meant for interactive `karma start` debugging. Under headless `singleRun` it makes Karma flag a false-positive full page reload and exit with an error. Restored the Karma default (`true`).

## Output

| Before | After |
|--------|--------|
| <img width="784" height="456" alt="Screenshot 2026-06-20 at 14 46 06" src="https://github.com/user-attachments/assets/5277f4bf-75e0-4be9-afb8-d69ae6fc1bff" />| <img width="785" height="354" alt="Screenshot 2026-06-20 at 14 45 35" src="https://github.com/user-attachments/assets/b04618f3-87d1-4a77-b19e-236ac65dd7a1" />|

## Verification

- Before: `Executed 123 of 123 SUCCESS` but `ERROR` exit, TS18028 + reload noise.
- After: `Executed 123 of 123 SUCCESS`, clean output, `exit 0`.