### PR TITLE
fix(useDebounce): retain `event.currentTarget` on debounced actions

### DIFF
--- a/spec/use-debounce/use-debounce_spec.ts
+++ b/spec/use-debounce/use-debounce_spec.ts
@@ -107,3 +107,41 @@ describe(`debounced controller action should retain Stimulus action params`, fun
     })
   })
 })
+
+// https://github.com/stimulus-use/stimulus-use/issues/91
+describe(`debounced controller action should retain event.currentTarget`, function () {
+  let application
+  let testLogger
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    setFixture(sameEventMultipleActions)
+    application.register('debounce', UseLogController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  it('retains currentTarget on the debounced action', async function () {
+    const waitValue = 200
+    const button = document.querySelector('#debounced')
+
+    click('#debounced')
+    await nextFrame()
+
+    expect(testLogger.eventsFilter({ name: ['a'] }).length).to.equal(0)
+    expect(testLogger.eventsFilter({ name: ['b'] }).length).to.equal(1)
+
+    await delay(waitValue + 10)
+    await nextFrame()
+
+    const aEvents = testLogger.eventsFilter({ name: ['a'] })
+    expect(aEvents.length).to.equal(1)
+    expect(aEvents[0].currentTarget).to.equal(button)
+  })
+})

--- a/spec/use-throttle/use-throttle_spec.ts
+++ b/spec/use-throttle/use-throttle_spec.ts
@@ -95,3 +95,33 @@ scenarios.forEach(scenario => {
     })
   })
 })
+
+// https://github.com/stimulus-use/stimulus-use/issues/91
+describe(`throttled controller action should retain event.currentTarget`, function () {
+  let application
+  let testLogger
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+    application.options = {}
+
+    setFixture(fixtureBase)
+    application.register('throttle', UseLogController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  it('retains currentTarget on the throttled action', async function () {
+    click('#throttled')
+    await nextFrame()
+
+    const aEvents = testLogger.eventsFilter({ name: ['a'] })
+    expect(aEvents.length).to.equal(1)
+    expect(aEvents[0].id).to.equal('throttled')
+  })
+})

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -25,9 +25,16 @@ export const debounce = (
     const args = Array.from(arguments)
     const context = this
     const params = args.map(arg => arg.params)
+    const currentTargets = args.map(arg => arg?.currentTarget)
 
     const callback = () => {
-      args.forEach((arg, index) => (arg.params = params[index]))
+      args.forEach((arg, index) => {
+        arg.params = params[index]
+
+        if (arg instanceof Event) {
+          Object.defineProperty(arg, 'currentTarget', { configurable: true, value: currentTargets[index] })
+        }
+      })
       return fn.apply(context, args)
     }
 


### PR DESCRIPTION
The browser resets `event.currentTarget` to `null` once dispatch finishes, so debounced handlers (run later via `setTimeout`) saw a null `currentTarget`. This pull request captures `currentTarget` while it's still valid and restore it before invoking the handler, mirroring the existing params handling.

Fixes #91 