### PR TITLE
fix(useDebounce): support non-event arguments without crashing

### DIFF
--- a/spec/use-debounce/use-debounce-arguments_spec.ts
+++ b/spec/use-debounce/use-debounce-arguments_spec.ts
@@ -1,0 +1,124 @@
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, TestLogger, delay, setFixture } from '../helpers'
+import UseLogArgumentController from './use_log_argument_controller'
+
+// https://github.com/stimulus-use/stimulus-use/issues/551
+describe(`debounced controller action invoked with arguments`, function () {
+  let application
+  let testLogger
+  let element
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+    application.options = {}
+
+    element = setFixture(`<div data-controller="debounce-arguments"></div>`).querySelector(
+      '[data-controller="debounce-arguments"]'
+    )
+    application.register('debounce-arguments', UseLogArgumentController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  beforeEach(function () {
+    testLogger.clear()
+  })
+
+  // https://github.com/stimulus-use/stimulus-use/issues/551 — primitive argument
+  it('debounces a method called with a primitive argument and passes it through', async function () {
+    const controller = application.getControllerForElementAndIdentifier(element, 'debounce-arguments')
+
+    controller.search('toto')
+
+    await delay(210)
+    await nextFrame()
+
+    const events = testLogger.eventsFilter({ name: ['search'] })
+    expect(events.length).to.equal(1)
+    expect(events[0].query).to.equal('toto')
+  })
+
+  // https://github.com/stimulus-use/stimulus-use/issues/295 — object argument without a `params` key
+  it('does not mutate a non-event object argument', async function () {
+    const controller = application.getControllerForElementAndIdentifier(element, 'debounce-arguments')
+    const argument = { mention: '/user/mentions' }
+
+    controller.search(argument)
+
+    await delay(210)
+    await nextFrame()
+
+    const events = testLogger.eventsFilter({ name: ['search'] })
+    expect(events.length).to.equal(1)
+    expect(events[0].query).to.equal(argument)
+    expect('params' in argument).to.equal(false)
+  })
+
+  it('passes multiple arguments through unchanged', async function () {
+    const controller = application.getControllerForElementAndIdentifier(element, 'debounce-arguments')
+
+    controller.search('query', 42, { page: 2 })
+
+    await delay(210)
+    await nextFrame()
+
+    const events = testLogger.eventsFilter({ name: ['search'] })
+    expect(events.length).to.equal(1)
+    expect(events[0].args).to.deep.equal(['query', 42, { page: 2 }])
+  })
+
+  const primitives = [
+    { label: 'a number', value: 42 },
+    { label: 'a boolean', value: false },
+    { label: 'null', value: null },
+    { label: 'undefined', value: undefined }
+  ]
+
+  primitives.forEach(({ label, value }) => {
+    it(`does not throw when called with ${label}`, async function () {
+      const controller = application.getControllerForElementAndIdentifier(element, 'debounce-arguments')
+
+      controller.search(value)
+
+      await delay(210)
+      await nextFrame()
+
+      const events = testLogger.eventsFilter({ name: ['search'] })
+      expect(events.length).to.equal(1)
+      expect(events[0].query).to.equal(value)
+    })
+  })
+
+  it('works when called with no arguments', async function () {
+    const controller = application.getControllerForElementAndIdentifier(element, 'debounce-arguments')
+
+    controller.search()
+
+    await delay(210)
+    await nextFrame()
+
+    const events = testLogger.eventsFilter({ name: ['search'] })
+    expect(events.length).to.equal(1)
+    expect(events[0].args).to.deep.equal([])
+  })
+
+  it('collapses rapid calls into a single trailing call with the latest arguments', async function () {
+    const controller = application.getControllerForElementAndIdentifier(element, 'debounce-arguments')
+
+    controller.search('first')
+    controller.search('second')
+    controller.search('third')
+
+    await delay(210)
+    await nextFrame()
+
+    const events = testLogger.eventsFilter({ name: ['search'] })
+    expect(events.length).to.equal(1)
+    expect(events[0].query).to.equal('third')
+  })
+})

--- a/spec/use-debounce/use_log_argument_controller.ts
+++ b/spec/use-debounce/use_log_argument_controller.ts
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus'
+import { useDebounce } from '../../src'
+
+export default class UseLogArgumentController extends Controller {
+  static debounces = ['search']
+
+  connect() {
+    useDebounce(this, this.application.options)
+  }
+
+  search(query) {
+    this.application.testLogger.log({ name: 'search', query, args: Array.from(arguments) })
+  }
+}

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -24,13 +24,13 @@ export const debounce = (
   return function (this: any): any {
     const args = Array.from(arguments)
     const context = this
-    const params = args.map(arg => (arg instanceof Event ? arg.params : undefined))
+    const params = args.map(arg => (arg instanceof Event ? (arg as any).params : undefined))
     const currentTargets = args.map(arg => (arg instanceof Event ? arg.currentTarget : undefined))
 
     const callback = () => {
       args.forEach((arg, index) => {
         if (arg instanceof Event) {
-          arg.params = params[index]
+          ;(arg as any).params = params[index]
           Object.defineProperty(arg, 'currentTarget', { configurable: true, value: currentTargets[index] })
         }
       })

--- a/src/use-debounce/use-debounce.ts
+++ b/src/use-debounce/use-debounce.ts
@@ -24,14 +24,13 @@ export const debounce = (
   return function (this: any): any {
     const args = Array.from(arguments)
     const context = this
-    const params = args.map(arg => arg.params)
-    const currentTargets = args.map(arg => arg?.currentTarget)
+    const params = args.map(arg => (arg instanceof Event ? arg.params : undefined))
+    const currentTargets = args.map(arg => (arg instanceof Event ? arg.currentTarget : undefined))
 
     const callback = () => {
       args.forEach((arg, index) => {
-        arg.params = params[index]
-
         if (arg instanceof Event) {
+          arg.params = params[index]
           Object.defineProperty(arg, 'currentTarget', { configurable: true, value: currentTargets[index] })
         }
       })


### PR DESCRIPTION
Restoring Stimulus action params on every argument threw a `TypeError` when a debounced method was called with a non-event value (e.g. a string from `tributejs` or `event.target.value`). 

Only restore `params`/`currentTarget` for `Event` arguments and pass everything else through untouched, leaving the shared-event params fix from #252 intact.

Closes #551
Closes #295