### PR TITLE
fix(useHotkeys): pass the HotkeysEvent as the second handler argument

### DIFF
--- a/spec/use-hotkeys/use-hotkeys-event_spec.ts
+++ b/spec/use-hotkeys/use-hotkeys-event_spec.ts
@@ -1,0 +1,37 @@
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, TestLogger, keyDown, keyUp, setFixture } from '../helpers'
+import UseHotkeysEventController from './use_hotkeys_event_controller'
+
+// https://github.com/stimulus-use/stimulus-use/issues/201
+describe(`useHotkeys passes the HotkeysEvent as the second handler argument`, function () {
+  let application
+  let testLogger
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    setFixture(`<div data-controller="hotkeys-event"></div>`)
+    application.register('hotkeys-event', UseHotkeysEventController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  it('invokes the handler with (KeyboardEvent, HotkeysEvent)', async function () {
+    keyDown('body', { key: 'x', keyCode: 88, which: 88 })
+    keyUp('body', { key: 'x', keyCode: 88, which: 88 })
+
+    const events = testLogger.eventsFilter({ name: ['recordHandler'] })
+    expect(events.length).to.equal(1)
+
+    const [event] = events
+    expect(event.firstIsKeyboardEvent).to.equal(true)
+    expect(event.secondIsKeyboardEvent).to.equal(false)
+    expect(event.shortcut).to.equal('x')
+    expect(event.scope).to.equal('all')
+  })
+})

--- a/spec/use-hotkeys/use_hotkeys_event_controller.ts
+++ b/spec/use-hotkeys/use_hotkeys_event_controller.ts
@@ -1,0 +1,20 @@
+import { Controller } from '@hotwired/stimulus'
+import { useHotkeys } from '../../src/hotkeys'
+
+export default class UseHotkeysEventController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      x: [this.recordHandler]
+    })
+  }
+
+  recordHandler(event, hotkeysEvent) {
+    this.application.testLogger.log({
+      name: 'recordHandler',
+      firstIsKeyboardEvent: event instanceof KeyboardEvent,
+      secondIsKeyboardEvent: hotkeysEvent instanceof KeyboardEvent,
+      shortcut: hotkeysEvent && hotkeysEvent.shortcut,
+      scope: hotkeysEvent && hotkeysEvent.scope
+    })
+  }
+}

--- a/src/use-hotkeys/use-hotkeys.ts
+++ b/src/use-hotkeys/use-hotkeys.ts
@@ -42,8 +42,8 @@ export class UseHotkeys extends StimulusUse {
   bind = () => {
     for (const [hotkey, definition] of Object.entries(this.hotkeysOptions.hotkeys as any)) {
       const handler = (definition as HotkeyDefinition).handler.bind(this.controller)
-      hotkeys(hotkey, (definition as HotkeyDefinition).options, (e: KeyboardEvent) =>
-        handler(e, e as unknown as HotkeysEvent)
+      hotkeys(hotkey, (definition as HotkeyDefinition).options, (e: KeyboardEvent, hotkeysEvent: HotkeysEvent) =>
+        handler(e, hotkeysEvent)
       )
     }
   }


### PR DESCRIPTION
The hotkeys-js callback forwarded the KeyboardEvent twice, so handlers received (KeyboardEvent, KeyboardEvent) instead of the documented (KeyboardEvent, HotkeysEvent). Forward the callback's own second argument.

Closes #201