### PR TITLE
fix(useHotkeys): apply the filter option in the simple form

### DIFF
--- a/spec/use-hotkeys/use-hotkeys-simple-filter_spec.ts
+++ b/spec/use-hotkeys/use-hotkeys-simple-filter_spec.ts
@@ -1,7 +1,12 @@
 import { Application } from '@hotwired/stimulus'
 import hotkeys from 'hotkeys-js'
 import { nextFrame, TestLogger, keyDown, keyUp, setFixture } from '../helpers'
-import UseHotkeysSimpleFilterController, { simpleFormFilter } from './use_hotkeys_simple_filter_controller'
+
+import UseHotkeysSimpleFilterController, {
+  UseHotkeysBlockingFilterController,
+  simpleFormFilter,
+  blockingFilter
+} from './use_hotkeys_simple_filter_controller'
 
 // https://github.com/stimulus-use/stimulus-use/issues/191
 describe(`useHotkeys filter option in the simple form`, function () {
@@ -22,6 +27,10 @@ describe(`useHotkeys filter option in the simple form`, function () {
     await application.stop()
   })
 
+  beforeEach(function () {
+    testLogger.clear()
+  })
+
   it('applies the filter option instead of treating it as a hotkey', function () {
     expect(hotkeys.filter).to.equal(simpleFormFilter)
   })
@@ -31,5 +40,47 @@ describe(`useHotkeys filter option in the simple form`, function () {
     keyUp('body', { key: 'b', keyCode: 66, which: 66 })
 
     expect(testLogger.eventsFilter({ name: ['bHandler'] }).length).to.equal(1)
+  })
+
+  it('binds every hotkey defined alongside the filter', async function () {
+    keyDown('body', { key: 'b', keyCode: 66, which: 66 })
+    keyUp('body', { key: 'b', keyCode: 66, which: 66 })
+    keyDown('body', { key: '/', keyCode: 191, which: 191 })
+    keyUp('body', { key: '/', keyCode: 191, which: 191 })
+
+    expect(testLogger.eventsFilter({ name: ['bHandler'] }).length).to.equal(1)
+    expect(testLogger.eventsFilter({ name: ['slashHandler'] }).length).to.equal(1)
+  })
+})
+
+describe(`useHotkeys filter option is consulted at runtime`, function () {
+  let application
+  let testLogger
+  let originalFilter
+
+  beforeAll(async function () {
+    originalFilter = hotkeys.filter
+
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    setFixture(`<div data-controller="hotkeys-blocking-filter"></div>`)
+    application.register('hotkeys-blocking-filter', UseHotkeysBlockingFilterController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+    hotkeys.filter = originalFilter
+  })
+
+  it('does not fire the hotkey when the filter returns false', async function () {
+    expect(hotkeys.filter).to.equal(blockingFilter)
+
+    keyDown('body', { key: 'b', keyCode: 66, which: 66 })
+    keyUp('body', { key: 'b', keyCode: 66, which: 66 })
+
+    expect(testLogger.eventsFilter({ name: ['blockedHandler'] }).length).to.equal(0)
   })
 })

--- a/spec/use-hotkeys/use-hotkeys-simple-filter_spec.ts
+++ b/spec/use-hotkeys/use-hotkeys-simple-filter_spec.ts
@@ -1,0 +1,35 @@
+import { Application } from '@hotwired/stimulus'
+import hotkeys from 'hotkeys-js'
+import { nextFrame, TestLogger, keyDown, keyUp, setFixture } from '../helpers'
+import UseHotkeysSimpleFilterController, { simpleFormFilter } from './use_hotkeys_simple_filter_controller'
+
+// https://github.com/stimulus-use/stimulus-use/issues/191
+describe(`useHotkeys filter option in the simple form`, function () {
+  let application
+  let testLogger
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    setFixture(`<div data-controller="hotkeys-simple-filter"></div>`)
+    application.register('hotkeys-simple-filter', UseHotkeysSimpleFilterController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  it('applies the filter option instead of treating it as a hotkey', function () {
+    expect(hotkeys.filter).to.equal(simpleFormFilter)
+  })
+
+  it('still binds the actual hotkey', async function () {
+    keyDown('body', { key: 'b', keyCode: 66, which: 66 })
+    keyUp('body', { key: 'b', keyCode: 66, which: 66 })
+
+    expect(testLogger.eventsFilter({ name: ['bHandler'] }).length).to.equal(1)
+  })
+})

--- a/spec/use-hotkeys/use_hotkeys_simple_filter_controller.ts
+++ b/spec/use-hotkeys/use_hotkeys_simple_filter_controller.ts
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus'
+import { useHotkeys } from '../../src/hotkeys'
+
+export const simpleFormFilter = () => true
+
+export default class UseHotkeysSimpleFilterController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      b: [this.bHandler],
+      filter: simpleFormFilter
+    })
+  }
+
+  bHandler(event) {
+    this.application.testLogger.log({ name: 'bHandler', type: event.type })
+  }
+}

--- a/spec/use-hotkeys/use_hotkeys_simple_filter_controller.ts
+++ b/spec/use-hotkeys/use_hotkeys_simple_filter_controller.ts
@@ -7,11 +7,31 @@ export default class UseHotkeysSimpleFilterController extends Controller {
   connect() {
     useHotkeys(this, {
       b: [this.bHandler],
+      '/': [this.slashHandler],
       filter: simpleFormFilter
     })
   }
 
   bHandler(event) {
     this.application.testLogger.log({ name: 'bHandler', type: event.type })
+  }
+
+  slashHandler(event) {
+    this.application.testLogger.log({ name: 'slashHandler', type: event.type })
+  }
+}
+
+export const blockingFilter = () => false
+
+export class UseHotkeysBlockingFilterController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      b: [this.bHandler],
+      filter: blockingFilter
+    })
+  }
+
+  bHandler(event) {
+    this.application.testLogger.log({ name: 'blockedHandler', type: event.type })
   }
 }

--- a/src/use-hotkeys/use-hotkeys.ts
+++ b/src/use-hotkeys/use-hotkeys.ts
@@ -82,8 +82,9 @@ const convertSimpleHotkeyDefinition = (definition: SimpleHotkeyDefinition): Hotk
 const coerceOptions = (options: HotkeysOptions | HotkeyDefinitions): HotkeysOptions => {
   if (!options.hotkeys) {
     const hotkeys = {}
+    const { filter, ...definitions } = options as HotkeysOptions
 
-    Object.entries(options as HotkeyDefinitions).forEach(([hotkey, definition]) => {
+    Object.entries(definitions as HotkeyDefinitions).forEach(([hotkey, definition]) => {
       Object.defineProperty(hotkeys, hotkey, {
         value: convertSimpleHotkeyDefinition(definition as SimpleHotkeyDefinition),
         writable: false,
@@ -92,7 +93,8 @@ const coerceOptions = (options: HotkeysOptions | HotkeyDefinitions): HotkeysOpti
     })
 
     options = {
-      hotkeys
+      hotkeys,
+      filter
     }
   }
 


### PR DESCRIPTION
In the simple form the filter option was treated as a hotkey definition, which both broke binding ("could not be bound") and meant the filter was never applied. Extract filter before building the hotkey map.

Closes #191