### PR TITLE
fix(useHotkeys): only unbind the disconnecting controller's handlers

### DIFF
--- a/spec/use-hotkeys/use-hotkeys-shared-key_spec.ts
+++ b/spec/use-hotkeys/use-hotkeys-shared-key_spec.ts
@@ -1,0 +1,47 @@
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, delay, TestLogger, keyDown, keyUp, setFixture } from '../helpers'
+import UseHotkeysSharedKeyController from './use_hotkeys_shared_key_controller'
+
+// https://github.com/stimulus-use/stimulus-use/issues/177
+describe(`useHotkeys only unbinds the disconnecting controller's handler`, function () {
+  let application
+  let testLogger
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    setFixture(`
+      <div data-controller="hotkeys-shared" id="first"></div>
+      <div data-controller="hotkeys-shared" id="second"></div>
+    `)
+
+    application.register('hotkeys-shared', UseHotkeysSharedKeyController)
+
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  it('keeps the remaining controller bound after another disconnects', async function () {
+    keyDown('#first', { key: 'b', keyCode: 66, which: 66 })
+    keyDown('#second', { key: 'b', keyCode: 66, which: 66 })
+
+    expect(testLogger.eventsFilter({ name: ['handle'], id: ['first'] }).length).to.equal(1)
+    expect(testLogger.eventsFilter({ name: ['handle'], id: ['second'] }).length).to.equal(1)
+
+    testLogger.clear()
+    document.querySelector('#first').remove()
+
+    await nextFrame()
+    await delay()
+
+    keyDown('#second', { key: 'b', keyCode: 66, which: 66 })
+    keyUp('#second', { key: 'b', keyCode: 66, which: 66 })
+
+    expect(testLogger.eventsFilter({ name: ['handle'], id: ['second'] }).length).to.equal(1)
+  })
+})

--- a/spec/use-hotkeys/use-hotkeys-shared-key_spec.ts
+++ b/spec/use-hotkeys/use-hotkeys-shared-key_spec.ts
@@ -1,6 +1,9 @@
+import hotkeys from 'hotkeys-js'
 import { Application } from '@hotwired/stimulus'
 import { nextFrame, delay, TestLogger, keyDown, keyUp, setFixture } from '../helpers'
 import UseHotkeysSharedKeyController from './use_hotkeys_shared_key_controller'
+
+const boundKeyCount = () => hotkeys.getAllKeyCodes().filter(registration => registration.shortcut === 'b').length
 
 // https://github.com/stimulus-use/stimulus-use/issues/177
 describe(`useHotkeys only unbinds the disconnecting controller's handler`, function () {
@@ -34,14 +37,18 @@ describe(`useHotkeys only unbinds the disconnecting controller's handler`, funct
     expect(testLogger.eventsFilter({ name: ['handle'], id: ['second'] }).length).to.equal(1)
 
     testLogger.clear()
+    const boundBefore = boundKeyCount()
     document.querySelector('#first').remove()
 
     await nextFrame()
     await delay()
 
+    expect(boundKeyCount()).to.equal(boundBefore - 1)
+
     keyDown('#second', { key: 'b', keyCode: 66, which: 66 })
     keyUp('#second', { key: 'b', keyCode: 66, which: 66 })
 
     expect(testLogger.eventsFilter({ name: ['handle'], id: ['second'] }).length).to.equal(1)
+    expect(testLogger.eventsFilter({ name: ['handle'], id: ['first'] }).length).to.equal(0)
   })
 })

--- a/spec/use-hotkeys/use-hotkeys-unbind_spec.ts
+++ b/spec/use-hotkeys/use-hotkeys-unbind_spec.ts
@@ -1,0 +1,129 @@
+import hotkeys from 'hotkeys-js'
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, delay, TestLogger, keyDown, keyUp, setFixture } from '../helpers'
+
+import {
+  UseHotkeysMultiKeyController,
+  UseHotkeysScopedController,
+  UseHotkeysReconnectController
+} from './use_hotkeys_unbind_controllers'
+
+const registrations = (predicate: (registration: any) => boolean) => hotkeys.getAllKeyCodes().filter(predicate)
+
+// https://github.com/stimulus-use/stimulus-use/issues/177
+describe(`useHotkeys unbind — broader coverage`, function () {
+  describe('a controller binding multiple keys', function () {
+    let application
+    let testLogger
+
+    beforeAll(async function () {
+      application = Application.start()
+      testLogger = new TestLogger()
+      application.testLogger = testLogger
+
+      setFixture(`
+        <div data-controller="hotkeys-multi" id="multi"></div>
+        <div data-controller="hotkeys-shared-multi" id="other"></div>
+      `)
+
+      application.register('hotkeys-multi', UseHotkeysMultiKeyController)
+      application.register('hotkeys-shared-multi', UseHotkeysMultiKeyController)
+
+      await nextFrame()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+    })
+
+    it('unbinds all of its own keys on disconnect, leaving another controller intact', async function () {
+      expect(registrations(r => r.shortcut === 'b').length).to.equal(2)
+      expect(registrations(r => r.shortcut === '/').length).to.equal(2)
+
+      document.querySelector('#multi').remove()
+      await nextFrame()
+      await delay()
+
+      expect(registrations(r => r.shortcut === 'b').length).to.equal(1)
+      expect(registrations(r => r.shortcut === '/').length).to.equal(1)
+
+      keyDown('#other', { key: 'b', keyCode: 66, which: 66 })
+      keyUp('#other', { key: 'b', keyCode: 66, which: 66 })
+      keyDown('#other', { key: '/', keyCode: 191, which: 191 })
+      keyUp('#other', { key: '/', keyCode: 191, which: 191 })
+
+      expect(testLogger.eventsFilter({ name: ['multi'], id: ['other'] }).length).to.equal(2)
+    })
+  })
+
+  describe('a controller binding a scoped key', function () {
+    let application
+    let testLogger
+
+    beforeAll(async function () {
+      application = Application.start()
+      testLogger = new TestLogger()
+      application.testLogger = testLogger
+
+      setFixture(`<div data-controller="hotkeys-scoped" id="scoped"></div>`)
+      application.register('hotkeys-scoped', UseHotkeysScopedController)
+      await nextFrame()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+    })
+
+    it('unbinds the binding under its own scope', async function () {
+      expect(registrations(r => r.shortcut === 'm' && r.scope === 'files').length).to.equal(1)
+
+      document.querySelector('#scoped').remove()
+      await nextFrame()
+      await delay()
+
+      expect(registrations(r => r.shortcut === 'm' && r.scope === 'files').length).to.equal(0)
+    })
+  })
+
+  describe('a controller that reconnects', function () {
+    let application
+    let testLogger
+    let fixture
+
+    beforeAll(async function () {
+      application = Application.start()
+      testLogger = new TestLogger()
+      application.testLogger = testLogger
+
+      fixture = setFixture(`<div data-controller="hotkeys-reconnect" id="reconnect"></div>`)
+      application.register('hotkeys-reconnect', UseHotkeysReconnectController)
+
+      await nextFrame()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+    })
+
+    it('rebinds its hotkey after disconnecting and reconnecting', async function () {
+      keyDown('#reconnect', { key: 'y', keyCode: 89, which: 89 })
+      keyUp('#reconnect', { key: 'y', keyCode: 89, which: 89 })
+      expect(testLogger.eventsFilter({ name: ['reconnect'] }).length).to.equal(1)
+
+      testLogger.clear()
+      document.querySelector('#reconnect').remove()
+      await nextFrame()
+      await delay()
+      expect(registrations(r => r.shortcut === 'y').length).to.equal(0)
+
+      fixture.innerHTML = `<div data-controller="hotkeys-reconnect" id="reconnect"></div>`
+      await nextFrame()
+      await delay()
+      expect(registrations(r => r.shortcut === 'y').length).to.equal(1)
+
+      keyDown('#reconnect', { key: 'y', keyCode: 89, which: 89 })
+      keyUp('#reconnect', { key: 'y', keyCode: 89, which: 89 })
+      expect(testLogger.eventsFilter({ name: ['reconnect'] }).length).to.equal(1)
+    })
+  })
+})

--- a/spec/use-hotkeys/use_hotkeys_shared_key_controller.ts
+++ b/spec/use-hotkeys/use_hotkeys_shared_key_controller.ts
@@ -1,0 +1,19 @@
+import { Controller } from '@hotwired/stimulus'
+import { useHotkeys } from '../../src/hotkeys'
+
+export default class UseHotkeysSharedKeyController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      hotkeys: {
+        b: {
+          handler: this.handle,
+          options: { element: this.element }
+        }
+      }
+    })
+  }
+
+  handle() {
+    this.application.testLogger.log({ name: 'handle', id: this.element.id })
+  }
+}

--- a/spec/use-hotkeys/use_hotkeys_unbind_controllers.ts
+++ b/spec/use-hotkeys/use_hotkeys_unbind_controllers.ts
@@ -1,0 +1,45 @@
+import { Controller } from '@hotwired/stimulus'
+import { useHotkeys } from '../../src/hotkeys'
+
+export class UseHotkeysMultiKeyController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      hotkeys: {
+        b: { handler: this.handle, options: { element: this.element } },
+        '/': { handler: this.handle, options: { element: this.element } }
+      }
+    })
+  }
+
+  handle(_event, hotkeysEvent) {
+    this.application.testLogger.log({ name: 'multi', id: this.element.id, shortcut: hotkeysEvent.shortcut })
+  }
+}
+
+export class UseHotkeysScopedController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      hotkeys: {
+        m: { handler: this.handle, options: { scope: 'files' } }
+      }
+    })
+  }
+
+  handle() {
+    this.application.testLogger.log({ name: 'scoped' })
+  }
+}
+
+export class UseHotkeysReconnectController extends Controller {
+  connect() {
+    useHotkeys(this, {
+      hotkeys: {
+        y: { handler: this.handle, options: { element: this.element } }
+      }
+    })
+  }
+
+  handle() {
+    this.application.testLogger.log({ name: 'reconnect', id: this.element.id })
+  }
+}

--- a/src/use-hotkeys/use-hotkeys.ts
+++ b/src/use-hotkeys/use-hotkeys.ts
@@ -30,6 +30,7 @@ export interface HotkeysOptions extends StimulusUseOptions {
 export class UseHotkeys extends StimulusUse {
   controller: Controller
   hotkeysOptions: HotkeysOptions
+  registrations: { hotkey: string; scope: string; callback: KeyHandler }[] = []
 
   constructor(controller: Controller, hotkeysOptions: HotkeysOptions) {
     super(controller, hotkeysOptions)
@@ -41,17 +42,18 @@ export class UseHotkeys extends StimulusUse {
 
   bind = () => {
     for (const [hotkey, definition] of Object.entries(this.hotkeysOptions.hotkeys as any)) {
+      const options = (definition as HotkeyDefinition).options
       const handler = (definition as HotkeyDefinition).handler.bind(this.controller)
-      hotkeys(hotkey, (definition as HotkeyDefinition).options, (e: KeyboardEvent, hotkeysEvent: HotkeysEvent) =>
-        handler(e, hotkeysEvent)
-      )
+      const callback = (e: KeyboardEvent, hotkeysEvent: HotkeysEvent) => handler(e, hotkeysEvent)
+
+      hotkeys(hotkey, options, callback)
+      this.registrations.push({ hotkey, scope: options?.scope || 'all', callback })
     }
   }
 
   unbind = () => {
-    for (const hotkey in this.hotkeysOptions.hotkeys as any) {
-      hotkeys.unbind(hotkey)
-    }
+    this.registrations.forEach(({ hotkey, scope, callback }) => hotkeys.unbind(hotkey, scope, callback))
+    this.registrations = []
   }
 
   private enhanceController() {


### PR DESCRIPTION
`unbind()` removed every handler registered for a key, so disconnecting one controller broke other controllers sharing the same hotkey. Track each registered callback and pass it (with its scope) to `hotkeys.unbind` so only that binding is removed.

Closes #177