### PR TITLE
fix(useResize): avoid `ResizeObserver loop` warning

### DIFF
--- a/spec/use-resize/use-resize_spec.ts
+++ b/spec/use-resize/use-resize_spec.ts
@@ -1,0 +1,50 @@
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, delay, TestLogger, setFixture } from '../helpers'
+import UseResizeController from './use_resize_controller'
+
+// https://github.com/stimulus-use/stimulus-use/issues/181
+describe(`useResize does not trigger the "ResizeObserver loop" warning`, function () {
+  let application
+  let testLogger
+  let resizeLoopErrors
+  let onError
+
+  beforeAll(async function () {
+    resizeLoopErrors = []
+    onError = (event: ErrorEvent) => {
+      if (typeof event.message === 'string' && event.message.includes('ResizeObserver loop')) {
+        resizeLoopErrors.push(event.message)
+        event.preventDefault()
+      }
+    }
+    window.addEventListener('error', onError)
+
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    setFixture(`<div data-controller="resize" id="box" style="width: 100px"></div>`)
+    application.register('resize', UseResizeController)
+
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+    window.removeEventListener('error', onError)
+  })
+
+  it('calls the resize callback without emitting the loop warning', async function () {
+    const box = document.querySelector('#box') as HTMLElement
+    for (let i = 0; i < 5; i++) {
+      box.style.width = `${120 + i * 20}px`
+      await nextFrame()
+      await delay()
+    }
+
+    await delay(50)
+
+    expect(testLogger.eventsFilter({ name: ['resize'] }).length).to.be.greaterThan(0)
+    expect(resizeLoopErrors.length).to.equal(0)
+  })
+})

--- a/spec/use-resize/use_resize_controller.ts
+++ b/spec/use-resize/use_resize_controller.ts
@@ -1,0 +1,13 @@
+import { Controller } from '@hotwired/stimulus'
+import { useResize } from '../../src'
+
+export default class UseResizeController extends Controller {
+  connect() {
+    useResize(this)
+  }
+
+  resize({ width }) {
+    ;(this.element as HTMLElement).style.height = `${Math.round(width)}px`
+    this.application.testLogger.log({ name: 'resize', width: Math.round(width) })
+  }
+}

--- a/src/use-resize/use-resize.ts
+++ b/src/use-resize/use-resize.ts
@@ -18,29 +18,44 @@ export const useResize = (composableController: Controller, options: ResizeOptio
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
 
-  const callback = (entries: ResizeObserverEntry[]) => {
-    const [entry] = entries
-    method(controller, 'resize').call(controller, entry.contentRect)
+  let frame: number | null = null
 
-    // emit a custom "controllerIdentifier:resize" event
-    if (dispatchEvent) {
-      const eventName = composeEventName('resize', controller, eventPrefix)
-      const appearEvent = extendedEvent(eventName, null, {
-        controller,
-        entry
-      })
-      targetElement.dispatchEvent(appearEvent)
-    }
+  const callback = (entries: ResizeObserverEntry[]) => {
+    if (frame !== null) cancelAnimationFrame(frame)
+
+    frame = requestAnimationFrame(() => {
+      frame = null
+
+      const [entry] = entries
+      method(controller, 'resize').call(controller, entry.contentRect)
+
+      // emit a custom "controllerIdentifier:resize" event
+      if (dispatchEvent) {
+        const eventName = composeEventName('resize', controller, eventPrefix)
+
+        const appearEvent = extendedEvent(eventName, null, {
+          controller,
+          entry
+        })
+
+        targetElement.dispatchEvent(appearEvent)
+      }
+    })
   }
 
   const controllerDisconnect = controller.disconnect.bind(controller)
-
   const observer = new ResizeObserver(callback)
 
   const observe = () => {
     observer.observe(targetElement)
   }
+
   const unobserve = () => {
+    if (frame !== null) {
+      cancelAnimationFrame(frame)
+      frame = null
+    }
+
     observer.unobserve(targetElement)
   }
 


### PR DESCRIPTION
Defer the observer callback to requestAnimationFrame so size changes made inside the resize callback don't re-trigger the observer within the same delivery, which produced the benign loop warning. Coalesce rapid resizes and cancel any pending frame on unobserve.

Closes #181