### PR TITLE
feat(useResize): support the `box` option for observation

### DIFF
--- a/docs/use-resize.md
+++ b/docs/use-resize.md
@@ -16,6 +16,7 @@ useResize(controller, options = {})
 
 | Option| Description |&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Default value&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;|
 |-----------------------|-------------|---------------------|
+| `box` | The [box model](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#box) the observation is based on. One of `content-box`, `border-box` or `device-pixel-content-box`. Use `border-box` to also be notified when padding or borders change.| `content-box` |
 | `dispatchEvent` | Whether to dispatch a `resize` event or not.| `true` |
 | `element` | The root element being observed for resize.| The controller element|
 |`eventPrefix`| Whether to prefix or not the emitted event. Can be a **boolean** or a **string**.<br>- **true** prefix the event with the controller identifier `card:resize` <br>- **someString** prefix the event with the given string `someString:resize` <br>- **false** to remove prefix  |true|

--- a/spec/use-resize/use-resize-box_spec.ts
+++ b/spec/use-resize/use-resize-box_spec.ts
@@ -1,0 +1,73 @@
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, delay, TestLogger, setFixture } from '../helpers'
+import { UseResizeLogController, UseResizeBorderBoxController } from './use_resize_behavior_controllers'
+
+const settle = async () => {
+  await nextFrame()
+  await delay()
+  await delay(50)
+}
+
+describe(`useResize box option`, function () {
+  describe('observing the border box', function () {
+    let application
+    let testLogger
+
+    beforeAll(async function () {
+      application = Application.start()
+      testLogger = new TestLogger()
+      application.testLogger = testLogger
+
+      setFixture(`<div data-controller="resize-borderbox" id="bb" style="box-sizing: content-box; width: 100px"></div>`)
+      application.register('resize-borderbox', UseResizeBorderBoxController)
+      await settle()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+    })
+
+    it('fires when padding changes the border box but not the content box', async function () {
+      const element = document.querySelector('#bb') as HTMLElement
+
+      testLogger.clear()
+      element.style.padding = '20px'
+      await settle()
+
+      expect(testLogger.eventsFilter({ name: ['resize-border'] }).length).to.be.greaterThan(0)
+    })
+  })
+
+  describe('observing the content box (default)', function () {
+    let application
+    let testLogger
+
+    beforeAll(async function () {
+      application = Application.start()
+      testLogger = new TestLogger()
+      application.testLogger = testLogger
+
+      setFixture(
+        `<div data-controller="resize-contentbox" id="cb" style="box-sizing: content-box; width: 100px"></div>`
+      )
+
+      application.register('resize-contentbox', UseResizeLogController)
+
+      await settle()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+    })
+
+    it('does not fire when only padding changes', async function () {
+      const element = document.querySelector('#cb') as HTMLElement
+
+      testLogger.clear()
+      element.style.padding = '20px'
+      await settle()
+
+      expect(testLogger.eventsFilter({ name: ['resize'] }).length).to.equal(0)
+    })
+  })
+})

--- a/spec/use-resize/use_resize_behavior_controllers.ts
+++ b/spec/use-resize/use_resize_behavior_controllers.ts
@@ -13,6 +13,16 @@ export class UseResizeLogController extends Controller {
   }
 }
 
+export class UseResizeBorderBoxController extends Controller {
+  connect() {
+    useResize(this, { box: 'border-box' })
+  }
+
+  resize(rect: DOMRectReadOnly) {
+    this.application.testLogger.log({ name: 'resize-border', width: Math.round(rect.width) })
+  }
+}
+
 export class UseResizeElementController extends Controller {
   static targets = ['observed']
 

--- a/src/use-resize/use-resize.ts
+++ b/src/use-resize/use-resize.ts
@@ -4,6 +4,7 @@ import { ResizeComposableController } from './resize-controller'
 
 export interface ResizeOptions {
   element?: Element
+  box?: ResizeObserverBoxOptions
   dispatchEvent?: boolean
   eventPrefix?: boolean | string
 }
@@ -17,6 +18,7 @@ export const useResize = (composableController: Controller, options: ResizeOptio
   const controller = composableController as ResizeComposableController
   const { dispatchEvent, eventPrefix } = Object.assign({}, defaultOptions, options)
   const targetElement: Element = options?.element || controller.element
+  const box = options?.box
 
   let frame: number | null = null
 
@@ -47,7 +49,7 @@ export const useResize = (composableController: Controller, options: ResizeOptio
   const observer = new ResizeObserver(callback)
 
   const observe = () => {
-    observer.observe(targetElement)
+    observer.observe(targetElement, box ? { box } : undefined)
   }
 
   const unobserve = () => {


### PR DESCRIPTION
Allow passing `box` (`'content-box' | 'border-box' | 'device-pixel-content-box'`) to choose which `box` `ResizeObserver` observes, forwarded to `observer.observe`.

Closes #582