### PR TITLE
fix(useMemo): memoize getters lazily on first access

### DIFF
--- a/docs/use-memo.md
+++ b/docs/use-memo.md
@@ -4,6 +4,12 @@ Adds one new behavior to your Stimulus controller : `memo`
 
 This behavior can be used to cache ("memoize") expensive getter methods, for example when parsing attributes passed in via the Stimulus Data API. All you need to do is to add a static array of getter method names `memos`, as you would define your `targets`. Then call `useMemo(this)` in your `connect()` callback and your getters are memoized.
 
+Memoization is **lazy**: calling `useMemo(this)` does not run your getters. Each getter runs the first time you access it, and its result is cached for every subsequent access.
+
+::: tip Only getters are memoized
+`useMemo` works with `get` accessors only. Plain methods listed in `memos` are left untouched (they are not memoized), since memoizing a method that may take arguments isn't well defined. If you want to cache the result of a method, expose it as a getter instead.
+:::
+
 ## Reference
 
 ```javascript

--- a/spec/use-memo/use-memo-lazy_spec.ts
+++ b/spec/use-memo/use-memo-lazy_spec.ts
@@ -1,0 +1,38 @@
+import { Application } from '@hotwired/stimulus'
+import { nextFrame, TestLogger, setFixture } from '../helpers'
+import UseMemoLazyController from './use_memo_lazy_controller'
+
+// https://github.com/stimulus-use/stimulus-use/issues/246
+describe(`useMemo memoizes getters lazily`, function () {
+  let application
+  let testLogger
+  let element
+
+  beforeAll(async function () {
+    application = Application.start()
+    testLogger = new TestLogger()
+    application.testLogger = testLogger
+
+    element = setFixture(`<div data-controller="memo-lazy"></div>`).querySelector('[data-controller="memo-lazy"]')
+    application.register('memo-lazy', UseMemoLazyController)
+    await nextFrame()
+  })
+
+  afterAll(async function () {
+    await application.stop()
+  })
+
+  it('does not evaluate the getter when useMemo() is called', function () {
+    const [event] = testLogger.eventsFilter({ name: ['afterUseMemo'] })
+    expect(event.evaluations).to.equal(0)
+  })
+
+  it('evaluates the getter once on first access and caches the result', function () {
+    const controller = application.getControllerForElementAndIdentifier(element, 'memo-lazy')
+
+    expect(controller.memoized).to.equal('value-1')
+    expect(controller.evaluations).to.equal(1)
+    expect(controller.memoized).to.equal('value-1')
+    expect(controller.evaluations).to.equal(1)
+  })
+})

--- a/spec/use-memo/use_memo_lazy_controller.ts
+++ b/spec/use-memo/use_memo_lazy_controller.ts
@@ -1,0 +1,19 @@
+import { Controller } from '@hotwired/stimulus'
+import { useMemo } from '../../src'
+
+export default class UseMemoLazyController extends Controller {
+  static memos = ['memoized']
+
+  evaluations = 0
+
+  connect() {
+    useMemo(this)
+
+    this.application.testLogger.log({ name: 'afterUseMemo', evaluations: this.evaluations })
+  }
+
+  get memoized() {
+    this.evaluations++
+    return `value-${this.evaluations}`
+  }
+}

--- a/src/use-memo/use-memo.ts
+++ b/src/use-memo/use-memo.ts
@@ -1,12 +1,32 @@
 import { Controller } from '@hotwired/stimulus'
 
-const memoize = (controller: Controller, name: string, value: any) => {
-  Object.defineProperty(controller, name, { value })
-  return value
+const findDescriptor = (controller: Controller, name: string): PropertyDescriptor | undefined => {
+  let prototype = Object.getPrototypeOf(controller)
+
+  while (prototype && prototype !== Object.prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, name)
+    if (descriptor) return descriptor
+
+    prototype = Object.getPrototypeOf(prototype)
+  }
+
+  return undefined
 }
 
 export const useMemo = (controller: Controller) => {
-  ;(controller.constructor as any).memos?.forEach((getter: string) => {
-    memoize(controller, getter, (controller as any)[getter])
+  ;(controller.constructor as any).memos?.forEach((name: string) => {
+    const descriptor = findDescriptor(controller, name)
+    if (!descriptor || typeof descriptor.get !== 'function') return
+
+    const getter = descriptor.get
+
+    Object.defineProperty(controller, name, {
+      configurable: true,
+      get(this: Controller) {
+        const value = getter.call(this)
+        Object.defineProperty(this, name, { value, configurable: true })
+        return value
+      }
+    })
   })
 }


### PR DESCRIPTION
Reading the value during `useMemo()` evaluated getters eagerly, contradicting the documented "memoize on first use" behavior. Replace each getter with a self-replacing lazy getter that computes and caches on first access. Leave non-getter entries untouched so methods stay callable. Document the lazy behavior and the getter-only support.

Closes #246