### PR TITLE
fix(debug): follow `application.debug` and deprecate `stimulusUseDebug`

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -4,6 +4,8 @@ Some `stimulus-use` mixins and controller have built in logging capabilities to 
 
 ## Global setting
 
+`stimulus-use` follows Stimulus' own [debug mode](https://stimulus.hotwired.dev/handbook/installing#debugging). Enable it on your application and `stimulus-use` will log too:
+
 ```js
 import { Application } from '@hotwired/stimulus'
 import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers'
@@ -12,15 +14,19 @@ const application = Application.start()
 const context = require.context('./controllers', true, /\.js$/)
 application.load(definitionsFromContext(context))
 
-// enable StimulusUse debug mode
-application.stimulusUseDebug = true
+// enable debug mode (Stimulus + stimulus-use)
+application.debug = true
 ```
 
 Another solution is to use the ENV variable to have something more dynamic per environment
 
 ```js
-application.stimulusUseDebug = process.env.NODE_ENV === 'development'
+application.debug = process.env.NODE_ENV === 'development'
 ```
+
+::: warning `application.stimulusUseDebug` is deprecated
+Earlier versions used a separate `application.stimulusUseDebug` flag. It still works as a fallback but is deprecated and will be removed in a future release, setting it logs a deprecation warning. Use Stimulus' built-in `application.debug` instead.
+:::
 
 ## Per mixin
 

--- a/spec/stimulus-use-debug_spec.ts
+++ b/spec/stimulus-use-debug_spec.ts
@@ -1,0 +1,115 @@
+import { Controller, Application } from '@hotwired/stimulus'
+import { useWindowFocus } from '../src'
+import { nextFrame, setFixture } from './helpers'
+
+const makeLogger = () => {
+  const calls: any[] = []
+  const noop = () => {}
+
+  return {
+    groupCollapsed: noop,
+    group: noop,
+    log: (...args: any[]) => calls.push(args),
+    table: noop,
+    warn: noop,
+    error: noop,
+    groupEnd: noop,
+    calls
+  }
+}
+
+class DebugController extends Controller {
+  connect() {
+    useWindowFocus(this, this.application.options)
+  }
+}
+
+const deprecationWarnings = (spy: any) =>
+  spy.mock.calls.filter((args: any[]) => String(args[0]).includes('stimulusUseDebug'))
+
+describe(`StimulusUse debug mode`, function () {
+  describe('with application.debug', function () {
+    let application: any
+    let logger: ReturnType<typeof makeLogger>
+    let warnSpy: any
+
+    beforeAll(async function () {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      logger = makeLogger()
+      application = Application.start()
+      application.debug = true
+      application.options = { logger }
+
+      setFixture(`<div data-controller="debug-app" id="d1"></div>`)
+      application.register('debug-app', DebugController)
+      await nextFrame()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+      warnSpy.mockRestore()
+    })
+
+    it('enables stimulus-use logging', function () {
+      expect(logger.calls.length).to.be.greaterThan(0)
+    })
+
+    it('does not emit a deprecation warning', function () {
+      expect(deprecationWarnings(warnSpy).length).to.equal(0)
+    })
+  })
+
+  describe('with the deprecated application.stimulusUseDebug', function () {
+    let application: any
+    let logger: ReturnType<typeof makeLogger>
+    let warnSpy: any
+
+    beforeAll(async function () {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      logger = makeLogger()
+      application = Application.start()
+      application.stimulusUseDebug = true
+      application.options = { logger }
+
+      setFixture(`<div data-controller="debug-legacy" id="d2"></div>`)
+      application.register('debug-legacy', DebugController)
+      await nextFrame()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+      warnSpy.mockRestore()
+    })
+
+    it('still enables logging (kept as a fallback)', function () {
+      expect(logger.calls.length).to.be.greaterThan(0)
+    })
+
+    it('emits a deprecation warning', function () {
+      expect(deprecationWarnings(warnSpy).length).to.be.greaterThan(0)
+    })
+  })
+
+  describe('without any debug flag', function () {
+    let application: any
+    let logger: ReturnType<typeof makeLogger>
+
+    beforeAll(async function () {
+      logger = makeLogger()
+      application = Application.start()
+      application.options = { logger }
+
+      setFixture(`<div data-controller="debug-off" id="d3"></div>`)
+      application.register('debug-off', DebugController)
+      await nextFrame()
+    })
+
+    afterAll(async function () {
+      await application.stop()
+    })
+
+    it('does not log', function () {
+      expect(logger.calls.length).to.equal(0)
+    })
+  })
+})

--- a/src/stimulus-use.ts
+++ b/src/stimulus-use.ts
@@ -29,7 +29,20 @@ export class StimulusUse {
   targetElement: Element
 
   constructor(controller: Controller, options: StimulusUseOptions = {}) {
-    this.debug = options?.debug ?? (controller.application as any).stimulusUseDebug ?? defaultOptions.debug
+    const application = controller.application as any
+
+    if (application.stimulusUseDebug !== undefined && !application.stimulusUseDebugWarned) {
+      application.stimulusUseDebugWarned = true
+      console.warn(
+        '[stimulus-use] `application.stimulusUseDebug` is deprecated and will be removed in a future release. ' +
+          'Use Stimulus’ built-in debug mode instead: `application.debug = true`. ' +
+          'https://stimulus.hotwired.dev/handbook/installing#debugging'
+      )
+    }
+
+    const globalDebug = application.debug || application.stimulusUseDebug || defaultOptions.debug
+
+    this.debug = options?.debug ?? globalDebug
     this.logger = options?.logger ?? defaultOptions.logger
     this.controller = controller
     this.controllerId = controller.element.id || (controller.element as HTMLElement).dataset.id


### PR DESCRIPTION
Drive stimulus-use logging off Stimulus' built-in `application.debug`. Keep `application.stimulusUseDebug` as a working fallback but emit a one-time deprecation warning when it is used.

Closes #595